### PR TITLE
[Translation] Changed translation domain, added some translations

### DIFF
--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -61,7 +61,6 @@ class PostAdmin extends Admin
                     'target' => 'content'
                 ))
                 ->add('rawContent')
-
             ->end()
             ->with('Tags')
                 ->add('tags', 'sonata_type_model', array('expanded' => false))
@@ -152,12 +151,12 @@ class PostAdmin extends Admin
         $id = $admin->getRequest()->get('id');
 
         $menu->addChild(
-            $this->trans('view_post'),
+            $this->trans('sidemenu.link_view_post'),
             array('uri' => $admin->generateUrl('edit', array('id' => $id)))
         );
 
         $menu->addChild(
-            $this->trans('link_view_comment'),
+            $this->trans('sidemenu.link_view_comments'),
             array('uri' => $admin->generateUrl('sonata.news.admin.comment.list', array('id' => $id)))
         );
     }

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -8,28 +8,35 @@
         <parameter key="sonata.news.admin.post.class">Sonata\NewsBundle\Admin\PostAdmin</parameter>
         <parameter key="sonata.news.admin.post.controller">SonataAdminBundle:CRUD</parameter>
         <parameter key="sonata.news.admin.post.entity">Application\Sonata\NewsBundle\Entity\Post</parameter>
+        <parameter key="sonata.news.admin.post.translation_domain">SonataNewsBundle</parameter>
 
         <!-- COMMENT -->
         <parameter key="sonata.news.admin.comment.class">Sonata\NewsBundle\Admin\CommentAdmin</parameter>
         <parameter key="sonata.news.admin.comment.controller">SonataAdminBundle:CRUD</parameter>
         <parameter key="sonata.news.admin.comment.entity">Application\Sonata\NewsBundle\Entity\Comment</parameter>
+        <parameter key="sonata.news.admin.comment.translation_domain">%sonata.news.admin.post.translation_domain%</parameter>
 
         <!-- TAG -->
         <parameter key="sonata.news.admin.tag.class">Sonata\NewsBundle\Admin\TagAdmin</parameter>
         <parameter key="sonata.news.admin.tag.controller">SonataAdminBundle:CRUD</parameter>
         <parameter key="sonata.news.admin.tag.entity">Application\Sonata\NewsBundle\Entity\Tag</parameter>
+        <parameter key="sonata.news.admin.tag.translation_domain">%sonata.news.admin.post.translation_domain%</parameter>
     </parameters>
 
     <services>
         <service id="sonata.news.admin.comment" class="%sonata.news.admin.comment.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="comment"/>
+            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="comments" />
             <argument />
             <argument>%sonata.news.admin.comment.entity%</argument>
             <argument>%sonata.news.admin.comment.controller%</argument>
+
+            <call method="setTranslationDomain">
+                <argument>%sonata.news.admin.comment.translation_domain%</argument>
+            </call>
         </service>
 
         <service id="sonata.news.admin.post" class="%sonata.news.admin.post.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="post"/>
+            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="posts" />
             <argument />
             <argument>%sonata.news.admin.post.entity%</argument>
             <argument>%sonata.news.admin.post.controller%</argument>
@@ -45,13 +52,21 @@
             <call method="addChild">
                 <argument type="service" id="sonata.news.admin.comment" />
             </call>
+
+            <call method="setTranslationDomain">
+                <argument>%sonata.news.admin.post.translation_domain%</argument>
+            </call>
         </service>
 
         <service id="sonata.news.admin.tag" class="%sonata.news.admin.tag.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="tag"/>
+            <tag name="sonata.admin" manager_type="orm" group="sonata_blog" label="tags" />
             <argument />
             <argument>%sonata.news.admin.tag.entity%</argument>
             <argument>%sonata.news.admin.tag.controller%</argument>
+
+            <call method="setTranslationDomain">
+                <argument>%sonata.news.admin.tag.translation_domain%</argument>
+            </call>
         </service>
     </services>
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -5,8 +5,11 @@
 
     <parameters>
         <parameter key="sonata.news.manager.comment.class">Sonata\NewsBundle\Entity\CommentManager</parameter>
+        <parameter key="sonata.news.manager.comment.entity">Application\Sonata\NewsBundle\Entity\Comment</parameter>
         <parameter key="sonata.news.manager.post.class">Sonata\NewsBundle\Entity\PostManager</parameter>
+        <parameter key="sonata.news.manager.post.entity">Application\Sonata\NewsBundle\Entity\Tag</parameter>
         <parameter key="sonata.news.manager.tag.class">Sonata\NewsBundle\Entity\TagManager</parameter>
+        <parameter key="sonata.news.manager.tag.entity">Application\Sonata\NewsBundle\Entity\Post</parameter>
     </parameters>
 
     <services>
@@ -14,17 +17,17 @@
 
         <service id="sonata.news.manager.comment" class="%sonata.news.manager.comment.class%">
             <argument type="service" id="sonata.news.entity_manager" />
-            <argument>Application\Sonata\NewsBundle\Entity\Comment</argument>
+            <argument>%sonata.news.manager.comment.entity%</argument>
         </service>
 
         <service id="sonata.news.manager.tag" class="%sonata.news.manager.tag.class%">
             <argument type="service" id="sonata.news.entity_manager" />
-            <argument>Application\Sonata\NewsBundle\Entity\Tag</argument>
+            <argument>%sonata.news.manager.post.entity%</argument>
         </service>
 
         <service id="sonata.news.manager.post" class="%sonata.news.manager.post.class%">
            <argument type="service" id="sonata.news.entity_manager" />
-           <argument>Application\Sonata\NewsBundle\Entity\Post</argument>
+           <argument>%sonata.news.manager.tag.entity%</argument>
         </service>
 
     </services>

--- a/Resources/translations/SonataNewsBundle.en.xliff
+++ b/Resources/translations/SonataNewsBundle.en.xliff
@@ -22,6 +22,64 @@
                 <source>no_post_found</source>
                 <target>No post found.</target>
             </trans-unit>
+            <trans-unit id="sidemenu.link_view_post">
+                <source>sidemenu.link_view_post</source>
+                <target>View</target>
+            </trans-unit>
+            <trans-unit id="sidemenu.link_view_comments">
+                <source>sidemenu.link_view_comments</source>
+                <target>Comments</target>
+            </trans-unit>
+
+            <trans-unit id="breadcrumb.link_comment_create">
+                <source>breadcrumb.link_comment_create</source>
+                <target>Create</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_comment_list">
+                <source>breadcrumb.link_comment_list</source>
+                <target>Comments</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_comment_edit">
+                <source>breadcrumb.link_comment_edit</source>
+                <target>Edit</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_post_create">
+                <source>breadcrumb.link_post_create</source>
+                <target>Create</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_post_list">
+                <source>breadcrumb.link_post_list</source>
+                <target>Posts</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_post_edit">
+                <source>breadcrumb.link_post_edit</source>
+                <target>Edit</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_tag_create">
+                <source>breadcrumb.link_tag_create</source>
+                <target>Create</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_tag_list">
+                <source>breadcrumb.link_tag_list</source>
+                <target>Tags</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_tag_edit">
+                <source>breadcrumb.link_tag_edit</source>
+                <target>Edit</target>
+            </trans-unit>
+
+            <trans-unit id="comments">
+                <source>comments</source>
+                <target>Comments</target>
+            </trans-unit>
+            <trans-unit id="posts">
+                <source>posts</source>
+                <target>Posts</target>
+            </trans-unit>
+            <trans-unit id="tags">
+                <source>tags</source>
+                <target>Tags</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
This is really similar to `SonataMediaBundle` [PR#58](https://github.com/sonata-project/SonataMediaBundle/pull/58)

Also, changed some translation keys:
1. `view_post` -> `sidemenu.link_view_post`
2. `link_view_comment` to `sidemenu.link_view_comments`
3. `(comment|tag|post)` to `(comment|tag|post)s`
