### PR TITLE
Updated some query criteria

### DIFF
--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -35,7 +35,7 @@ class PostController extends Controller
      * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
      */
     public function renderArchive(array $criteria = array(), array $parameters = array())
-    {
+    {   
         $pager = $this->getPostManager()->getPager(
             $criteria,
             $this->getRequest()->get('page', 1)
@@ -83,7 +83,7 @@ class PostController extends Controller
             throw new NotFoundHttpException('Unable to find the tag');
         }
 
-        return $this->renderArchive(array('tag' => $tag), array('tag' => $tag));
+        return $this->renderArchive(array('tag' => $tag->getSlug()), array('tag' => $tag));
     }
 
     /**

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -391,7 +391,7 @@ abstract class Post implements PostInterface
 
     public function isPublic()
     {
-        if (!$this->getEnabled()) {
+        if (!$this->getEnabled() || $this->getCategory() && !$this->getCategory()->getEnabled()) {
             return false;
         }
 


### PR DESCRIPTION
_PostController_: because the query for the tag page is **'t.slug LIKE :tag'** the value of the parameter can't be the object, but it should be the slug.

_PostManager_: Replaced **isset($urlParameters['category']** for **array_key_exists('category', $urlParameters)** because when the $urlParameter['category'] is NULL the getPublicationCategoryQueryParts() create the query 'p.category IS NULL'.

This mean if I get one post with the category 'test' and the slug 'my-post', the permalink is 'test/my-post'. Without the array_key_exists() condition 'blog/test/my-post' and 'blog/my-post' return the same page... when the correct should be a 404 error for the 'blog/my-post'.

Also added some conditions to only show the list of the public posts.
