### PR TITLE
Allow to use links with slash at the end

### DIFF
--- a/Permalink/CategoryPermalink.php
+++ b/Permalink/CategoryPermalink.php
@@ -34,6 +34,7 @@ class CategoryPermalink implements PermalinkInterface
      */
     public function getParameters($permalink)
     {
+        $permalink = trim($permalink, '/');
         $parameters = explode('/', $permalink);
 
         if (count($parameters) > 2 || count($parameters) == 0) {

--- a/Permalink/DatePermalink.php
+++ b/Permalink/DatePermalink.php
@@ -37,6 +37,7 @@ class DatePermalink implements PermalinkInterface
      */
     public function getParameters($permalink)
     {
+        $permalink = trim($permalink, '/');
         $parameters = explode('/', $permalink);
 
         if (count($parameters) != 4) {


### PR DESCRIPTION
This is for users who want to use `pattern:  /{permalink}/` instead of `pattern:  /{permalink}`
