### PR TITLE
Fix incorrect mongodb schema

### DIFF
--- a/Resources/config/doctrine/BaseCategory.mongodb.xml
+++ b/Resources/config/doctrine/BaseCategory.mongodb.xml
@@ -11,7 +11,7 @@
         <field name="slug"          type="string"       fieldName="slug"    />
 
         <field name="description"   type="string"   fieldName="description"    />
-        <field name="count"         type="integer"  fieldName="count"          />
+        <field name="count"         type="int"      fieldName="count"          />
 
         <field name="createdAt"    type="timestamp"   fieldName="createdAt" />
         <field name="updatedAt"    type="timestamp"   fieldName="updatedAt" />

--- a/Resources/config/doctrine/BasePost.mongodb.xml
+++ b/Resources/config/doctrine/BasePost.mongodb.xml
@@ -21,7 +21,7 @@
         <field name="commentsEnabled"       type="boolean"      fieldName="commentsEnabled" />
         <field name="commentsCloseAt"       type="timestamp"    fieldName="commentsCloseAt" />
         <field name="commentsDefaultStatus" type="int"          fieldName="commentsDefaultStatus" />
-        <field name="commentsCount"         type="integer"      fieldName="comments_count" default="0"/>
+        <field name="commentsCount"         type="int"          fieldName="comments_count" default="0"/>
 
         <field name="createdAt"             type="timestamp"    fieldName="createdAt" />
         <field name="updatedAt"             type="timestamp"    fieldName="updatedAt" />


### PR DESCRIPTION
Fixed incorrect field type in mongodb schema - causes 'Invalid type specified - integer' on cache warmup - they should be int.

IamPersistent has already corrected a couple of these - see f369e6b081f97bed3633ff7a30af9d7abc8c688b. So merge me quick please :)'
