### PR TITLE
Bug: Inconsistent variable naming template <-> controller

### DIFF
--- a/Resources/views/Post/view.html.twig
+++ b/Resources/views/Post/view.html.twig
@@ -40,7 +40,7 @@
         {{ post.content|raw }}
     </div>
 
-    {% render 'SonataNewsBundle:Post:comments' with {'post_id': post.id} %}
+    {% render 'SonataNewsBundle:Post:comments' with {'postId': post.id} %}
 
     {% if post.iscommentable %}
         {% render 'SonataNewsBundle:Post:addCommentForm' with {


### PR DESCRIPTION
Fixing the following bug:

```
An exception has been thrown during the rendering of a template ("Controller "Sonata\NewsBundle\Controller\PostController::commentsAction()" requires that you provide a value for the "$postId" argument (because there is no default value or because there is a non optional argument after this one).") in SonataNewsBundle:Post:view.html.twig at line 43.
```

by renaming the variable passed from the twig template.
