### PR TITLE
Unimplemented abstract method causes a Fatal error when using the bundle

### DIFF
--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -16,6 +16,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\NewsBundle\Model\PostInterface;
 
 class CommentManager extends ModelCommentManager
 {


### PR DESCRIPTION
The method "updateCommentsCount" was not implemented on the class

```
Sonata\NewsBundle\Document\CommentManager
```

causing a Fatal error when using the bundle so I've implemented the method.

Kind Regards,
