### PR TITLE
SONATA-321 - Enable modal for post status & post enabled comments status

### DIFF
--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -104,9 +104,15 @@ class PostAdmin extends Admin
             ->addIdentifier('title')
             ->add('author')
             ->add('collection')
-            ->add('enabled', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('tags')
-            ->add('commentsEnabled', null, array('editable' => true))
+            ->add('commentsEnabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('commentsCount')
             ->add('publicationDateStart')
         ;


### PR DESCRIPTION
Added confirmation modal for post status `enabled` & post `commentsEnabled` fields in administration list template.

Merge or the following PR is needed before: sonata-project/SonataAdminBundle#1873
