### PR TITLE
SONATA-341 - Fix recent comments block link to go on post if not granted...

### DIFF
--- a/Resources/views/Block/recent_comments.html.twig
+++ b/Resources/views/Block/recent_comments.html.twig
@@ -36,7 +36,11 @@ file that was distributed with this source code.
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ url('admin_sonata_news_comment_edit', { 'id': comment.id }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}</a>
+                        {% if is_granted('ROLE_SONATA_ADMIN') %}
+                            <a href="{{ url('admin_sonata_news_comment_edit', { 'id': comment.id }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}</a>
+                        {% else %}
+                            <a href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(comment.post) }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}</a>
+                        {% endif %}
                     </li>
                 {% endif %}
             {% else %}


### PR DESCRIPTION
... to admin

I've fixed link to go on post on which comment was added instead of going to admin with a 403 error (access denied).
