### PR TITLE
Fix recent comments block link for non-admin contexts

### DIFF
--- a/Resources/views/Block/recent_comments.html.twig
+++ b/Resources/views/Block/recent_comments.html.twig
@@ -36,7 +36,7 @@ file that was distributed with this source code.
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ url('admin_sonata_news_comment_edit', { 'id': comment.id }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}</a>
+                        <a href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(comment.post) }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}</a>
                     </li>
                 {% endif %}
             {% else %}


### PR DESCRIPTION
I've fixed the link as discussed in the previous PR https://github.com/sonata-project/SonataNewsBundle/pull/151
