### PR TITLE
Add Post & Comment POST/PUT/DELETE API methods

### DIFF
--- a/Controller/Api/CommentController.php
+++ b/Controller/Api/CommentController.php
@@ -13,13 +13,16 @@ namespace Sonata\NewsBundle\Controller\Api;
 
 use FOS\RestBundle\Controller\Annotations\View;
 
+use JMS\Serializer\SerializationContext;
+
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 
 use Sonata\NewsBundle\Model\Comment;
-
 use Sonata\NewsBundle\Model\CommentManagerInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Class CommentController
@@ -36,13 +39,20 @@ class CommentController
     protected $commentManager;
 
     /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
      * Constructor
      *
-     * @param CommentManagerInterface $commentManager
+     * @param CommentManagerInterface $commentManager A comment manager
+     * @param FormFactoryInterface    $formFactory    Symfony form factory
      */
-    public function __construct(CommentManagerInterface $commentManager)
+    public function __construct(CommentManagerInterface $commentManager, FormFactoryInterface $formFactory)
     {
         $this->commentManager = $commentManager;
+        $this->formFactory    = $formFactory;
     }
 
     /**
@@ -69,7 +79,103 @@ class CommentController
      */
     public function getCommentAction($id)
     {
-        $comment = $this->commentManager->findOneBy(array('id' => $id));
+        return $this->getComment($id);
+    }
+
+    /**
+     * Updates a comment
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="comment identifier"}
+     *  },
+     *  input={"class"="sonata_news_api_form_comment", "name"="", "groups"={"sonata_api_write"}},
+     *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"={"sonata_api_read"}},
+     *  statusCodes={
+     *      200="Returned when successful",
+     *      400="Returned when an error has occured while comment update",
+     *      404="Returned when unable to find comment"
+     *  }
+     * )
+     *
+     * @param integer $id      A Comment identifier
+     * @param Request $request A Symfony request
+     *
+     * @return Comment
+     *
+     * @throws NotFoundHttpException
+     */
+    public function putCommentAction($id, Request $request)
+    {
+        $comment = $this->getComment($id);
+
+        $form = $this->formFactory->createNamed(null, 'sonata_news_api_form_comment', $comment, array(
+            'csrf_protection' => false
+        ));
+
+        $form->bind($request);
+
+        if ($form->isValid()) {
+            $comment = $form->getData();
+            $this->commentManager->save($comment);
+
+            $view = \FOS\RestBundle\View\View::create($comment);
+            $serializationContext = SerializationContext::create();
+            $serializationContext->setGroups(array('sonata_api_read'));
+            $serializationContext->enableMaxDepthChecks();
+            $view->setSerializationContext($serializationContext);
+
+            return $view;
+        }
+
+        return $form;
+    }
+
+    /**
+     * Deletes a comment
+     *
+     * @ApiDoc(
+     *  requirements={
+     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="comment identifier"}
+     *  },
+     *  statusCodes={
+     *      200="Returned when comment is successfully deleted",
+     *      400="Returned when an error has occured while comment deletion",
+     *      404="Returned when unable to find comment"
+     *  }
+     * )
+     *
+     * @param integer $id A Comment identifier
+     *
+     * @return \FOS\RestBundle\View\View
+     *
+     * @throws NotFoundHttpException
+     */
+    public function deleteCommentAction($id)
+    {
+        $comment = $this->getComment($id);
+
+        try {
+            $this->commentManager->delete($comment);
+        } catch (\Exception $e) {
+            return \FOS\RestBundle\View\View::create(array('error' => $e->getMessage()), 400);
+        }
+
+        return array('deleted' => true);
+    }
+
+    /**
+     * Returns a comment entity instance
+     *
+     * @param integer $id A Comment identifier
+     *
+     * @return Comment
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    protected function getComment($id)
+    {
+        $comment = $this->commentManager->find($id);
 
         if (null === $comment) {
             throw new NotFoundHttpException(sprintf("Comment (%d) not found", $id));

--- a/DependencyInjection/SonataNewsExtension.php
+++ b/DependencyInjection/SonataNewsExtension.php
@@ -52,6 +52,7 @@ class SonataNewsExtension extends Extension
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
+            $loader->load('api_form.xml');
             $loader->load('serializer.xml');
         }
 
@@ -139,124 +140,125 @@ class SonataNewsExtension extends Extension
         }
 
         $collector->addAssociation($config['class']['post'], 'mapOneToMany', array(
-             'fieldName' => 'comments',
-             'targetEntity' => $config['class']['comment'],
-             'cascade' =>
-             array(
-                 0 => 'remove',
-                 1 => 'persist',
-             ),
-             'mappedBy' => 'post',
-             'orphanRemoval' => true,
-             'orderBy' =>
-             array(
-                 'createdAt' => 'DESC',
-             ),
+            'fieldName' => 'comments',
+            'targetEntity' => $config['class']['comment'],
+            'cascade' =>
+                array(
+                    0 => 'remove',
+                    1 => 'persist',
+                ),
+            'mappedBy' => 'post',
+            'orphanRemoval' => true,
+            'orderBy' =>
+                array(
+                    'createdAt' => 'DESC',
+                ),
         ));
 
         $collector->addAssociation($config['class']['post'], 'mapManyToOne', array(
             'fieldName' => 'image',
             'targetEntity' => $config['class']['media'],
             'cascade' =>
-            array(
-                0 => 'remove',
-                1 => 'persist',
-                2 => 'refresh',
-                3 => 'merge',
-                4 => 'detach',
-            ),
+                array(
+                    0 => 'remove',
+                    1 => 'persist',
+                    2 => 'refresh',
+                    3 => 'merge',
+                    4 => 'detach',
+                ),
             'mappedBy' => NULL,
             'inversedBy' => NULL,
             'joinColumns' =>
-            array(
                 array(
-                    'name' => 'image_id',
-                    'referencedColumnName' => 'id',
+                    array(
+                        'name' => 'image_id',
+                        'referencedColumnName' => 'id',
+                    ),
                 ),
-            ),
             'orphanRemoval' => false,
         ));
 
         $collector->addAssociation($config['class']['post'], 'mapManyToOne', array(
-             'fieldName' => 'author',
-             'targetEntity' => $config['class']['user'],
-             'cascade' =>
-             array(
-                 1 => 'persist',
-             ),
-             'mappedBy' => NULL,
-             'inversedBy' => NULL,
-             'joinColumns' =>
-             array(
-                 array(
-                     'name' => 'author_id',
-                     'referencedColumnName' => 'id',
-                 ),
-             ),
-             'orphanRemoval' => false,
+            'fieldName' => 'author',
+            'targetEntity' => $config['class']['user'],
+            'cascade' =>
+                array(
+                    1 => 'persist',
+                ),
+            'mappedBy' => NULL,
+            'inversedBy' => NULL,
+            'joinColumns' =>
+                array(
+                    array(
+                        'name' => 'author_id',
+                        'referencedColumnName' => 'id',
+                    ),
+                ),
+            'orphanRemoval' => false,
         ));
 
         $collector->addAssociation($config['class']['post'], 'mapManyToOne', array(
-             'fieldName' => 'collection',
-             'targetEntity' => $config['class']['collection'],
-             'cascade' =>
-             array(
-                 1 => 'persist',
-             ),
-             'mappedBy' => NULL,
-             'inversedBy' => NULL,
-             'joinColumns' =>
-             array(
-                 array(
-                     'name' => 'collection_id',
-                     'referencedColumnName' => 'id',
-                 ),
-             ),
-             'orphanRemoval' => false,
+            'fieldName' => 'collection',
+            'targetEntity' => $config['class']['collection'],
+            'cascade' =>
+                array(
+                    1 => 'persist',
+                ),
+            'mappedBy' => NULL,
+            'inversedBy' => NULL,
+            'joinColumns' =>
+                array(
+                    array(
+                        'name' => 'collection_id',
+                        'referencedColumnName' => 'id',
+                    ),
+                ),
+            'orphanRemoval' => false,
         ));
 
         $collector->addAssociation($config['class']['post'], 'mapManyToMany', array(
             'fieldName' => 'tags',
             'targetEntity' => $config['class']['tag'],
             'cascade' =>
-            array(
-                1 => 'persist',
-            ),
+                array(
+                    1 => 'persist',
+                ),
             'joinTable' =>
-            array(
-                'name' => 'news__post_tag',
-                'joinColumns' =>
+                array(
+                    'name' => 'news__post_tag',
+                    'joinColumns' =>
+                        array(
+                            array(
+                                'name' => 'post_id',
+                                'referencedColumnName' => 'id',
+                            ),
+                        ),
+                    'inverseJoinColumns' =>
+                        array(
+                            array(
+                                'name' => 'tag_id',
+                                'referencedColumnName' => 'id',
+                            ),
+                        ),
+                ),
+        ));
+
+        $collector->addAssociation($config['class']['comment'], 'mapManyToOne', array(
+            'fieldName' => 'post',
+            'targetEntity' => $config['class']['post'],
+            'cascade' => array(
+            ),
+            'mappedBy' => NULL,
+            'inversedBy' => 'comments',
+            'joinColumns' =>
                 array(
                     array(
                         'name' => 'post_id',
                         'referencedColumnName' => 'id',
+                        'nullable' => false
                     ),
                 ),
-                'inverseJoinColumns' =>
-                array(
-                    array(
-                        'name' => 'tag_id',
-                        'referencedColumnName' => 'id',
-                    ),
-                ),
-            ),
-        ));
-
-        $collector->addAssociation($config['class']['comment'], 'mapManyToOne', array(
-             'fieldName' => 'post',
-             'targetEntity' => $config['class']['post'],
-             'cascade' => array(
-             ),
-             'mappedBy' => NULL,
-             'inversedBy' => 'comments',
-             'joinColumns' =>
-             array(
-                 array(
-                     'name' => 'post_id',
-                     'referencedColumnName' => 'id',
-                 ),
-             ),
-             'orphanRemoval' => false,
+            'orphanRemoval' => false,
         ));
     }
 }

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -406,6 +406,22 @@ abstract class Post implements PostInterface
     /**
      * {@inheritdoc}
      */
+    public function setImage($image)
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setCollection(CollectionInterface $collection = null)
     {
         $this->collection = $collection;

--- a/Model/PostInterface.php
+++ b/Model/PostInterface.php
@@ -234,7 +234,7 @@ interface PostInterface
     /**
      * Set comments_count
      *
-     * @param integer $commentsDefaultStatus
+     * @param integer $commentscount
      */
     public function setCommentsCount($commentscount);
 
@@ -266,6 +266,18 @@ interface PostInterface
      * @return mixed
      */
     public function getAuthor();
+
+    /**
+     * @param mixed $image
+     *
+     * @return mixed
+     */
+    public function setImage($image);
+
+    /**
+     * @return mixed
+     */
+    public function getImage();
 
     /**
      * @return \Sonata\ClassificationBundle\Model\CollectionInterface

--- a/Resources/config/api_controllers.xml
+++ b/Resources/config/api_controllers.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="sonata.news.controller.api.comment" class="Sonata\NewsBundle\Controller\Api\CommentController">
             <argument type="service" id="sonata.news.manager.comment" />
+            <argument type="service" id="form.factory" />
         </service>
 
         <service id="sonata.news.controller.api.post" class="Sonata\NewsBundle\Controller\Api\PostController">
@@ -14,6 +15,7 @@
             <argument type="service" id="sonata.news.manager.comment" />
             <argument type="service" id="sonata.news.mailer" />
             <argument type="service" id="form.factory" />
+            <argument type="service" id="sonata.formatter.pool" />
         </service>
     </services>
 

--- a/Resources/config/api_form.xml
+++ b/Resources/config/api_form.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sonata.news.api.form.type.comment" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+            <tag name="form.type" alias="sonata_news_api_form_comment" />
+
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="doctrine" />
+            <argument>sonata_news_api_form_comment</argument>
+            <argument>%sonata.news.admin.comment.entity%</argument>
+            <argument>sonata_api_write</argument>
+        </service>
+
+        <service id="sonata.news.api.form.type.post" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+            <tag name="form.type" alias="sonata_news_api_form_post" />
+
+            <argument type="service" id="jms_serializer.metadata_factory" />
+            <argument type="service" id="doctrine" />
+            <argument>sonata_news_api_form_post</argument>
+            <argument>%sonata.news.admin.post.entity%</argument>
+            <argument>sonata_api_write</argument>
+        </service>
+    </services>
+</container>

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -7,7 +7,6 @@
     <services>
         <service id="sonata.news.form.type.comment" class="Sonata\NewsBundle\Form\Type\CommentType">
             <tag name="form.type" alias="sonata_post_comment" />
-
         </service>
     </services>
 </container>

--- a/Tests/Controller/Api/CommentControllerTest.php
+++ b/Tests/Controller/Api/CommentControllerTest.php
@@ -12,7 +12,8 @@
 namespace Sonata\NewsBundle\Tests\Controller\Api;
 
 use Sonata\NewsBundle\Controller\Api\CommentController;
-
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * Class CommentControllerTest
@@ -29,13 +30,13 @@ class CommentControllerTest extends \PHPUnit_Framework_TestCase
         $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
 
         $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
-        $commentManager->expects($this->once())->method('findOneBy')->will($this->returnValue($comment));
+        $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
 
         $this->assertEquals($comment, $this->createCommentController($commentManager)->getCommentAction(1));
     }
 
     /**
-     * @expectedException        Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedException        \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @expectedExceptionMessage Comment (42) not found
      */
     public function testGetCommentNotFoundExceptionAction()
@@ -45,15 +46,85 @@ class CommentControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param null $commentManager
+     * @param null $formFactory
      *
      * @return CommentController
      */
-    protected function createCommentController($commentManager = null)
+    protected function createCommentController($commentManager = null, $formFactory = null)
     {
         if (null === $commentManager) {
             $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         }
 
-        return new CommentController($commentManager);
+        if (null === $formFactory) {
+            $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        }
+
+        return new CommentController($commentManager, $formFactory);
+    }
+
+    public function testPutCommentAction()
+    {
+        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+
+        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
+        $commentManager->expects($this->once())->method('save')->will($this->returnValue($comment));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCommentController($commentManager, $formFactory)->putCommentAction(1, new Request());
+
+        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+    }
+
+    public function testPutCommentInvalidAction()
+    {
+        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+
+        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
+        $commentManager->expects($this->never())->method('save')->will($this->returnValue($comment));
+
+        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form->expects($this->once())->method('bind');
+        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+
+        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+
+        $view = $this->createCommentController($commentManager, $formFactory)->putCommentAction(1, new Request());
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+    }
+
+    public function testDeleteCommentAction()
+    {
+        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+
+        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
+        $commentManager->expects($this->once())->method('delete');
+
+        $view = $this->createCommentController($commentManager)->deleteCommentAction(1);
+
+        $this->assertEquals(array('deleted' => true), $view);
+    }
+
+    public function testDeletePostInvalidAction()
+    {
+        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager->expects($this->once())->method('find')->will($this->returnValue(null));
+        $commentManager->expects($this->never())->method('delete');
+
+        $this->createCommentController($commentManager)->deleteCommentAction(1);
     }
 }

--- a/Tests/Model/CommentTest.php
+++ b/Tests/Model/CommentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\Model;
+
+class ModelTest_Comment extends \Sonata\NewsBundle\Model\Comment
+{
+    public function getId()
+    {
+
+    }
+}
+
+/**
+ * Class CommentTest
+ *
+ * Tests the comment model
+ */
+class CommentTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSettersGetters()
+    {
+        $date = new \DateTime();
+
+        $comment = new ModelTest_Comment();
+        $comment->setCreatedAt($date);
+        $comment->setEmail('email@example.org');
+        $comment->setMessage('My message');
+        $comment->setName('My name');
+        $comment->setPost($this->getMock('Sonata\NewsBundle\Model\PostInterface'));
+        $comment->setStatus(1);
+        $comment->setUpdatedAt($date);
+        $comment->setUrl('http://www.example.org');
+
+        $this->assertEquals($comment->getCreatedAt(), $date);
+        $this->assertEquals($comment->getEmail(), 'email@example.org');
+        $this->assertEquals($comment->getMessage(), 'My message');
+        $this->assertEquals($comment->getName(), 'My name');
+        $this->assertEquals($comment->getPost(), $this->getMock('Sonata\NewsBundle\Model\PostInterface'));
+        $this->assertEquals($comment->getStatus(), 1);
+        $this->assertEquals($comment->getUpdatedAt(), $date);
+        $this->assertEquals($comment->getUrl(), 'http://www.example.org');
+    }
+}

--- a/Tests/Model/PostTest.php
+++ b/Tests/Model/PostTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\Model;
+
+class ModelTest_Post extends \Sonata\NewsBundle\Model\Post
+{
+    public function getId()
+    {
+
+    }
+}
+
+/**
+ * Class PostTest
+ *
+ * Tests the post model
+ */
+class PostTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSettersGetters()
+    {
+        $date = new \DateTime();
+
+        $post = new ModelTest_Post();
+        $post->setAbstract('My abstract content');
+        $post->setAuthor('My author');
+        $post->setCollection($this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
+        $post->setCommentsCloseAt($date);
+        $post->setCommentsCount(5);
+        $post->setCommentsDefaultStatus(1);
+        $post->setCommentsEnabled(true);
+        $post->setContent('My content');
+        $post->setContentFormatter('markdown');
+        $post->setCreatedAt($date);
+        $post->setEnabled(true);
+        $post->setPublicationDateStart($date);
+        $post->setRawContent('My raw content');
+        $post->setTags($this->getMock('Sonata\ClassificationBundle\Model\TagInterface'));
+        $post->setTitle('My title');
+        $post->setSlug('my-post-slug');
+        $post->setUpdatedAt($date);
+
+        $this->assertEquals($post->getAbstract(), 'My abstract content');
+        $this->assertEquals($post->getAuthor(), 'My author');
+        $this->assertEquals($post->getCollection(), $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
+        $this->assertEquals($post->getCommentsCloseAt(), $date);
+        $this->assertEquals($post->getCommentsCount(), 5);
+        $this->assertEquals($post->getCommentsDefaultStatus(), 1);
+        $this->assertEquals($post->getCommentsEnabled(), true);
+        $this->assertEquals($post->getContent(), 'My content');
+        $this->assertEquals($post->getContentFormatter(), 'markdown');
+        $this->assertEquals($post->getCreatedAt(), $date);
+        $this->assertEquals($post->getEnabled(), true);
+        $this->assertEquals($post->getPublicationDateStart(), $date);
+        $this->assertEquals($post->getRawContent(), 'My raw content');
+        $this->assertEquals($post->getSlug(), 'my-post-slug');
+        $this->assertEquals($post->getTags(), $this->getMock('Sonata\ClassificationBundle\Model\TagInterface'));
+        $this->assertEquals($post->getTitle(), 'My title');
+        $this->assertEquals($post->getUpdatedAt(), $date);
+    }
+}


### PR DESCRIPTION
I've added `POST`, `PUT` and `DELETE` methods for posts and comments:

![capture decran 2014-02-26 a 12 37 11](https://f.cloud.github.com/assets/103900/2269476/6f18520e-9eda-11e3-94e1-cbcb048b89b5.png)

This PR should be merged after this one: https://github.com/sonata-project/SonataCoreBundle/pull/45
