### PR TITLE
Fix post comment add method

### DIFF
--- a/Controller/Api/PostController.php
+++ b/Controller/Api/PostController.php
@@ -286,14 +286,17 @@ class PostController
         }
 
         $comment = $this->commentManager->create();
-        $comment->setPost($post);
-        $comment->setStatus($post->getCommentsDefaultStatus());
 
         $form = $this->formFactory->createNamed(null, 'sonata_news_api_form_comment', $comment, array('csrf_protection' => false));
         $form->bind($request);
 
         if ($form->isValid()) {
             $comment = $form->getData();
+            $comment->setPost($post);
+
+            if (!$comment->getStatus()) {
+                $comment->setStatus($post->getCommentsDefaultStatus());
+            }
 
             $this->commentManager->save($comment);
             $this->mailer->sendCommentNotification($comment);


### PR DESCRIPTION
I've fixed method to work properly and avoid this issue:

``` json
{
  "code": 500,
  "message": "An exception occurred while executing 'INSERT INTO news__comment (name, url, email, message, status, created_at, updated_at, post_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)' with params [\"grou\", \"http:\\/\\/sonata-project.org\", \"em@il.com\", \"grou\", null, \"2014-03-12 15:44:43\", \"2014-03-12 15:44:43\", null]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1048 Column 'status' cannot be null"
}
```
