### PR TITLE
Missing jmsserializer instance on appkerner. Update installation.rst

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -42,8 +42,7 @@ Installation
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),
             new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
             new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
-
-
+            new JMS\SerializerBundle\JMSSerializerBundle(),
             // ...
         );
     }


### PR DESCRIPTION
Installing the bundle I got 
  The service "sonata.classification.api.form.type.category" has a dependency on a non-existent service "jms_serializer.metadata_factory".

The library was present but not loaded on AppKernel.
Adding it solved the problem...
