### PR TITLE
Api parameters validation

### DIFF
--- a/Model/Comment.php
+++ b/Model/Comment.php
@@ -142,14 +142,6 @@ abstract class Comment implements CommentInterface
     /**
      * {@inheritdoc}
      */
-    public static function getStatusNumberList()
-    {
-        return array_keys(self::getStatusList());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getStatusCode()
     {
         $status = self::getStatusList();

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -59,8 +59,9 @@
         </property>
 
         <property name="status">
-            <constraint name="Choice">
-                <option name="callback">getStatusNumberList</option>
+            <constraint name="Range">
+                <option name="min">0</option>
+                <option name="max">2</option>
             </constraint>
         </property>
 


### PR DESCRIPTION
Add missing field validation used with news bundle API
Requires PR sonata-project/SonataFormatterBundle/pull/65
