### PR TITLE
Don't remove the media item when the news item is removed

### DIFF
--- a/DependencyInjection/SonataNewsExtension.php
+++ b/DependencyInjection/SonataNewsExtension.php
@@ -160,7 +160,6 @@ class SonataNewsExtension extends Extension
             'targetEntity' => $config['class']['media'],
             'cascade' =>
                 array(
-                    0 => 'remove',
                     1 => 'persist',
                     2 => 'refresh',
                     3 => 'merge',


### PR DESCRIPTION
When you remove a news item the linked media item is also removed. However the same media item can be linked to multiple news items. If this is the case, you first have to unlink the media item before you can remove the news item. I think this leads to a poor user experience.

Also the media item may have been used for something else then the news item. So deleting the media item can cause broken links.
