### PR TITLE
[Travis-CI] Enabled Symfony 2.6 and 2.7 and disabled Symfony 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
   - SYMFONY_VERSION=2.3.*
   - SYMFONY_VERSION=2.4.*
   - SYMFONY_VERSION=2.5.*
-  - SYMFONY_VERSION=dev-master
+  - SYMFONY_VERSION=2.6.*
+  - SYMFONY_VERSION=2.7.*@dev
 
 before_script:
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update


### PR DESCRIPTION
Enabled Symfony 2.6 and 2.7 and disabled Symfony 3.x in travis.
