### PR TITLE
Add support for PostgreSQL in the command 'sonata:news:sync-comments-cou...

### DIFF
--- a/Entity/CommentManager.php
+++ b/Entity/CommentManager.php
@@ -53,6 +53,49 @@ class CommentManager extends BaseEntityManager implements CommentManagerInterfac
     }
 
     /**
+     * 
+     * @param string $postTableName
+     * @return string
+     */
+    private function getCommentsCountResetQuery($postTableName)
+    {
+        switch ($this->getConnection()->getDriver()->getDatabasePlatform()->getName())
+        {
+            case 'postgresql':
+                return sprintf('UPDATE %s SET comments_count = 0' , $postTableName);
+                
+            default :
+                return sprintf('UPDATE %s p SET p.comments_count = 0' , $postTableName);
+        }
+    }
+
+    /**
+     * 
+     * @param string $postTableName
+     * @param string $commentTableName
+     * @return string
+     */
+    private function getCommentsCountQuery($postTableName, $commentTableName)
+    {
+        switch ($this->getConnection()->getDriver()->getDatabasePlatform()->getName())
+        {
+            case 'postgresql':
+                return sprintf(
+            'UPDATE %s SET comments_count = count_comment.total
+            FROM (SELECT c.post_id, count(*) AS total FROM %s AS c WHERE c.status = 1 GROUP BY c.post_id) count_comment
+            WHERE %s.id = count_comment.post_id'
+        , $postTableName, $commentTableName, $postTableName);
+                
+            default :
+                return sprintf(
+            'UPDATE %s p, (SELECT c.post_id, count(*) as total FROM %s as c WHERE c.status = 1 GROUP BY c.post_id) as count_comment
+            SET p.comments_count = count_comment.total
+            WHERE p.id = count_comment.post_id'
+        , $postTableName, $commentTableName);
+        }
+    }
+
+    /**
      * Update the number of comment for a comment
      *
      * @param null|\Sonata\NewsBundle\Model\PostInterface $post
@@ -63,15 +106,11 @@ class CommentManager extends BaseEntityManager implements CommentManagerInterfac
     {
         $commentTableName = $this->getObjectManager()->getClassMetadata($this->getClass())->table['name'];
         $postTableName    = $this->getObjectManager()->getClassMetadata($this->postManager->getClass())->table['name'];
-
+        
         $this->getConnection()->beginTransaction();
-        $this->getConnection()->query(sprintf('UPDATE %s p SET p.comments_count = 0' , $postTableName));
+        $this->getConnection()->query($this->getCommentsCountResetQuery($postTableName));
 
-        $this->getConnection()->query(sprintf(
-            'UPDATE %s p, (SELECT c.post_id, count(*) as total FROM %s as c WHERE c.status = 1 GROUP BY c.post_id) as count_comment
-            SET p.comments_count = count_comment.total
-            WHERE p.id = count_comment.post_id'
-        , $postTableName, $commentTableName));
+        $this->getConnection()->query($this->getCommentsCountQuery($postTableName, $commentTableName));
 
         $this->getConnection()->commit();
     }


### PR DESCRIPTION
The command 'sonata:news:sync-comments-count' invokes the comment manager but this service uses a raw SQL query with a syntax that is not supported by PostgreSQL. 