### PR TITLE
Correct permission check for images on posts list

### DIFF
--- a/Resources/views/Admin/list_post_custom.html.twig
+++ b/Resources/views/Admin/list_post_custom.html.twig
@@ -14,8 +14,12 @@ file that was distributed with this source code.
 {% block field %}
     <div class="col-sm-2 centered">
         <center>
-            {% if object.image and admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
-                <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}" style="float: left; margin-right: 6px;">{% thumbnail object.image, 'admin' with {'width': 90} %}</a>
+            {% if object.image and admin.isGranted('VIEW', object.image) %}
+                {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
+                    <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}">{% thumbnail object.image, 'admin' with {'width': 90} %}</a>
+                {% else %}
+                    {% thumbnail object.image, 'admin' with {'width': 90} %}
+                {% endif %}
             {% else %}
                 <i class="fa fa-chain-broken fa-3x"></i>
             {% endif %}


### PR DESCRIPTION
I've ACL permissions setup,
I've posts with images, but if the current user is only ```VIEW``` granted on a post, he cannot view the post's image.

**Before**
![schermata del 2015-05-25 10 49 48](https://cloud.githubusercontent.com/assets/4598274/7794739/e39b0a10-02cd-11e5-890c-38046e806bfa.png)

**After**
![schermata del 2015-05-25 11 04 23](https://cloud.githubusercontent.com/assets/4598274/7794743/ef5dc40a-02cd-11e5-8acd-8d3483005555.png)

