### PR TITLE
use translation keys for admin group names

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -33,25 +33,25 @@ class CommentAdmin extends Admin
     {
         // define group zoning
         $formMapper
-            ->with($this->trans('group_comment'), array('class' => 'col-md-6'))->end()
-            ->with($this->trans('group_general'), array('class' => 'col-md-6'))->end()
+            ->with('group_comment', array('class' => 'col-md-6'))->end()
+            ->with('group_general', array('class' => 'col-md-6'))->end()
         ;
 
         if (!$this->isChild()) {
             $formMapper
-                ->with($this->trans('group_general'))
+                ->with('group_general')
                     ->add('post', 'sonata_type_model_list')
                 ->end()
             ;
         }
 
         $formMapper
-            ->with($this->trans('group_general'))
+            ->with('group_general')
                 ->add('name')
                 ->add('email')
                 ->add('url', null, array('required' => false))
             ->end()
-            ->with($this->trans('group_comment'))
+            ->with('group_comment')
                 ->add('status', 'sonata_news_comment_status', array(
                     'expanded' => true,
                     'multiple' => false,

--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -61,7 +61,7 @@ class PostAdmin extends Admin
     protected function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with('Post', array(
+            ->with('group_post', array(
                     'class' => 'col-md-8',
                 ))
                 ->add('author', 'sonata_type_model_list')
@@ -80,7 +80,7 @@ class PostAdmin extends Admin
                     'listener'             => true,
                 ))
             ->end()
-            ->with('Status', array(
+            ->with('group_status', array(
                     'class' => 'col-md-4',
                 ))
                 ->add('enabled', null, array('required' => false))
@@ -100,7 +100,7 @@ class PostAdmin extends Admin
                 ->add('commentsDefaultStatus', 'sonata_news_comment_status', array('expanded' => true))
             ->end()
 
-            ->with('Classification', array(
+            ->with('group_classification', array(
                 'class' => 'col-md-4',
                 ))
                 ->add('tags', 'sonata_type_model_autocomplete', array(

--- a/Resources/translations/SonataNewsBundle.cs.xliff
+++ b/Resources/translations/SonataNewsBundle.cs.xliff
@@ -415,6 +415,18 @@ Rychlé odkazy na moderování
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.de.xliff
+++ b/Resources/translations/SonataNewsBundle.de.xliff
@@ -423,6 +423,18 @@
                 <source>show.label_tags</source>
                 <target>Tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>Artikel</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>Status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>Klassifizierung</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.en.xliff
+++ b/Resources/translations/SonataNewsBundle.en.xliff
@@ -415,6 +415,18 @@ Quick moderation links :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>Post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>Status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>Classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.es.xliff
+++ b/Resources/translations/SonataNewsBundle.es.xliff
@@ -415,6 +415,18 @@ Modera el comentario de forma rápida :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>Artículo</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>Estado</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>Clasificación</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.fr.xliff
+++ b/Resources/translations/SonataNewsBundle.fr.xliff
@@ -415,6 +415,18 @@ Liens de modération rapide :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>Article</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>Statut</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>Classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.hu.xliff
+++ b/Resources/translations/SonataNewsBundle.hu.xliff
@@ -415,6 +415,18 @@ Gyors moderálási linkek:
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>Bejegyzés</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>Státusz</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>Osztályozás</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.ja.xliff
+++ b/Resources/translations/SonataNewsBundle.ja.xliff
@@ -415,6 +415,18 @@ Quick moderation links :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.nl.xliff
+++ b/Resources/translations/SonataNewsBundle.nl.xliff
@@ -414,6 +414,18 @@ Quick moderation links :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.pt_BR.xliff
+++ b/Resources/translations/SonataNewsBundle.pt_BR.xliff
@@ -415,6 +415,18 @@ Links rápidos de moderação :
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.ru.xliff
+++ b/Resources/translations/SonataNewsBundle.ru.xliff
@@ -416,6 +416,18 @@
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.sk.xliff
+++ b/Resources/translations/SonataNewsBundle.sk.xliff
@@ -415,6 +415,18 @@ Rýchle odkazy na moderovanie:
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataNewsBundle.sl.xliff
+++ b/Resources/translations/SonataNewsBundle.sl.xliff
@@ -415,6 +415,18 @@ Hitre moderatorske povezave:
                 <source>show.label_tags</source>
                 <target>show_label_tags</target>
             </trans-unit>
+            <trans-unit id="group_post">
+                <source>group_post</source>
+                <target>group_post</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>group_status</source>
+                <target>group_status</target>
+            </trans-unit>
+            <trans-unit id="group_classification">
+                <source>group_classification</source>
+                <target>group_classification</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Removed duplicate translation for ``CommentAdmin`` groups and renamed the ``PostAdmin`` group labels.