### PR TITLE
Return empty post when there is a permalink exception

### DIFF
--- a/Entity/PostManager.php
+++ b/Entity/PostManager.php
@@ -34,44 +34,46 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
 
         $query = $repository->createQueryBuilder('p');
 
-        $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
+        try {
+            $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
 
-        $parameters = array();
+            $parameters = array();
 
-        if (isset($urlParameters['year']) && isset($urlParameters['month']) && isset($urlParameters['day'])) {
-            $pdqp = $this->getPublicationDateQueryParts(sprintf('%d-%d-%d', $urlParameters['year'], $urlParameters['month'], $urlParameters['day']), 'day');
+            if (isset($urlParameters['year']) && isset($urlParameters['month']) && isset($urlParameters['day'])) {
+                $pdqp = $this->getPublicationDateQueryParts(sprintf('%d-%d-%d', $urlParameters['year'], $urlParameters['month'], $urlParameters['day']), 'day');
 
-            $parameters = array_merge($parameters, $pdqp['params']);
+                $parameters = array_merge($parameters, $pdqp['params']);
 
-            $query->andWhere($pdqp['query']);
-        }
+                $query->andWhere($pdqp['query']);
+            }
 
-        if (isset($urlParameters['slug'])) {
-            $query->andWhere('p.slug = :slug');
-            $parameters['slug'] = $urlParameters['slug'];
-        }
+            if (isset($urlParameters['slug'])) {
+                $query->andWhere('p.slug = :slug');
+                $parameters['slug'] = $urlParameters['slug'];
+            }
 
-        if (isset($urlParameters['collection'])) {
-            $pcqp = $this->getPublicationCollectionQueryParts($urlParameters['collection']);
+            if (isset($urlParameters['collection'])) {
+                $pcqp = $this->getPublicationCollectionQueryParts($urlParameters['collection']);
 
-            $parameters = array_merge($parameters, $pcqp['params']);
+                $parameters = array_merge($parameters, $pcqp['params']);
 
-            $query
-                ->leftJoin('p.collection', 'c')
-                ->andWhere($pcqp['query'])
-            ;
-        }
+                $query
+                    ->leftJoin('p.collection', 'c')
+                    ->andWhere($pcqp['query']);
+            }
 
-        if (count($parameters) == 0) {
-            return;
-        }
+            if (count($parameters) == 0) {
+                return;
+            }
 
-        $query->setParameters($parameters);
+            $query->setParameters($parameters);
 
-        $results = $query->getQuery()->getResult();
+            $results = $query->getQuery()->getResult();
 
-        if (count($results) > 0) {
-            return $results[0];
+            if (count($results) > 0) {
+                return $results[0];
+            }
+        } catch (\InvalidArgumentException $e) {
         }
 
         return;

--- a/Permalink/PermalinkInterface.php
+++ b/Permalink/PermalinkInterface.php
@@ -24,6 +24,8 @@ interface PermalinkInterface
      * @param string $permalink
      *
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     public function getParameters($permalink);
 }


### PR DESCRIPTION
When using an invalid permalink format the ``\InvalidArgumentException`` is not handled and thrown to the front.