### PR TITLE
Fixed showing only one tag while filtering archive by tag

### DIFF
--- a/Entity/PostManager.php
+++ b/Entity/PostManager.php
@@ -128,7 +128,9 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
         }
 
         if (isset($criteria['tag'])) {
-            $query->andWhere('t.slug LIKE :tag');
+            $query
+                ->leftJoin('p.tags', 't2')
+                ->andWhere('t2.slug LIKE :tag');
             $parameters['tag'] = (string) $criteria['tag'];
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #268 
Replaces #269

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed showing only one tag while filtering archive by tag
```

### Subject
While showing a news archive for a tag, only that tag was displayed in the post list.