### PR TITLE
use AbstractAdmin instead of deprecated Admin class

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -11,14 +11,14 @@
 
 namespace Sonata\NewsBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
 
-class CommentAdmin extends Admin
+class CommentAdmin extends AbstractAdmin
 {
     protected $parentAssociationMapping = 'post';
 

--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\NewsBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -23,7 +23,7 @@ use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Permalink\PermalinkInterface;
 use Sonata\UserBundle\Model\UserManagerInterface;
 
-class PostAdmin extends Admin
+class PostAdmin extends AbstractAdmin
 {
     /**
      * @var UserManagerInterface

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "symfony/symfony": "^2.3",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/user-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.0",
         "sonata-project/classification-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fix deprecated usage of `Admin` class
```

### Subject

The `Admin` class is deprecated since SonataAdminBundle `3.1`