### PR TITLE
Use twig blocks for form rendering

### DIFF
--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -257,7 +257,12 @@ class PostController extends Controller
         $comment->setPost($post);
         $comment->setStatus($post->getCommentsDefaultStatus());
 
-        return $this->get('form.factory')->createNamed('comment', 'sonata_post_comment', $comment);
+        return $this->get('form.factory')->createNamed('comment', 'sonata_post_comment', $comment, array(
+            'action' => $this->generateUrl('sonata_news_add_comment', array(
+                'id' => $post->getId(),
+            )),
+            'method' => 'POST',
+        ));
     }
 
     /**

--- a/Resources/views/Post/comment_form.html.twig
+++ b/Resources/views/Post/comment_form.html.twig
@@ -16,11 +16,11 @@
         <h3>{{'title_leave_comment'|trans({}, 'SonataNewsBundle') }}</h3>
     </div>
     <div class="panel-body">
-        <form action="{{ url('sonata_news_add_comment', {'id': post_id}) }}" method="POST" class="form-horizontal" role="form">
+        {{ form_start(form, { attr: { class: 'form-horizontal', role: 'form' } }) }}
             {{ form_widget(form) }}
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary"><i class="glyphicon glyphicon-pencil"></i>&nbsp;{{'btn_add_comment'|trans({}, 'SonataNewsBundle') }}</button>
             </div>
-        </form>
+        {{ form_end(form) }}
     </div>
 </div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this a minor change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced html `form` element with twig function
```


## Subject

This decouples the business logic from the layout.
