### PR TITLE
Fixed wrong StyleCI Bridge composer section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,11 @@
         "sonata-project/seo-bundle": "^2.0",
         "friendsofsymfony/rest-bundle": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",
-        "jms/serializer-bundle": "^0.13 || ^1.0"
+        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "conflict": {
         "jms/serializer": "<0.13",
-        "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
         "sonata-project/seo-bundle": "<2.0 || >=3.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix for development only.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

StyleCI wouldn't run, because the dependency was added to the `conflict` section instead of `require-dev`.

