### PR TITLE
Fixed duplicate translation in tab menu

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -35,12 +35,14 @@ class CommentAdmin extends AbstractAdmin
         $actions = parent::getBatchActions();
 
         $actions['enabled'] = array(
-            'label' => $this->trans($this->getLabelTranslatorStrategy()->getLabel('enable', 'batch', 'comment')),
+            'label' => $this->getLabelTranslatorStrategy()->getLabel('enable', 'batch', 'comment'),
+            'translation_domain' => $this->getTranslationDomain(),
             'ask_confirmation' => false,
         );
 
         $actions['disabled'] = array(
-            'label' => $this->trans($this->getLabelTranslatorStrategy()->getLabel('disable', 'batch', 'comment')),
+            'label' => $this->getLabelTranslatorStrategy()->getLabel('disable', 'batch', 'comment'),
+            'translation_domain' => $this->getTranslationDomain(),
             'ask_confirmation' => false,
         );
 

--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -221,8 +221,7 @@ class PostAdmin extends AbstractAdmin
         );
 
         if ($this->hasSubject() && $this->getSubject()->getId() !== null) {
-            $menu->addChild(
-                $this->trans('sidemenu.link_view_post'),
+            $menu->addChild('sidemenu.link_view_post',
                 array('uri' => $admin->getRouteGenerator()->generate('sonata_news_view', array('permalink' => $this->permalinkGenerator->generate($this->getSubject()))))
             );
         }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "symfony/symfony": "^2.3",
-        "sonata-project/admin-bundle": "^3.1",
+        "sonata-project/admin-bundle": "^3.4",
         "sonata-project/user-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.0",
         "sonata-project/classification-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed duplicate translation in tab menu
```

## Subject

Since the 3.4 release of the admin bundle, the menu items are translated in the twig templates by the knp menu bundle.
