### PR TITLE
fix missing configuration to use the CoreBundle's FormHelper

### DIFF
--- a/Form/Type/ApiCommentType.php
+++ b/Form/Type/ApiCommentType.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Form\Type;
+
+use Sonata\CoreBundle\Form\Type\BaseDoctrineORMSerializationType;
+
+/**
+ * @author  Thomas Rabaix <thomas.rabaix@gmail.com>
+ */
+class ApiCommentType extends BaseDoctrineORMSerializationType
+{
+}

--- a/Form/Type/ApiPostType.php
+++ b/Form/Type/ApiPostType.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Form\Type;
+
+use Sonata\CoreBundle\Form\Type\BaseDoctrineORMSerializationType;
+
+/**
+ * @author  Thomas Rabaix <thomas.rabaix@gmail.com>
+ */
+class ApiPostType extends BaseDoctrineORMSerializationType
+{
+}

--- a/Resources/config/api_form.xml
+++ b/Resources/config/api_form.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.news.api.form.type.comment" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+        <service id="sonata.news.api.form.type.comment" class="Sonata\NewsBundle\Form\Type\ApiCommentType">
             <tag name="form.type" alias="sonata_news_api_form_comment"/>
             <argument type="service" id="jms_serializer.metadata_factory"/>
             <argument type="service" id="doctrine"/>
@@ -9,7 +9,7 @@
             <argument>%sonata.news.admin.comment.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
-        <service id="sonata.news.api.form.type.post" class="Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType">
+        <service id="sonata.news.api.form.type.post" class="Sonata\NewsBundle\Form\Type\ApiPostType">
             <tag name="form.type" alias="sonata_news_api_form_post"/>
             <argument type="service" id="jms_serializer.metadata_factory"/>
             <argument type="service" id="doctrine"/>

--- a/SonataNewsBundle.php
+++ b/SonataNewsBundle.php
@@ -41,8 +41,8 @@ class SonataNewsBundle extends Bundle
         FormHelper::registerFormTypeMapping(array(
             'sonata_post_comment' => 'Sonata\NewsBundle\Form\Type\CommentType',
             'sonata_news_comment_status' => 'Sonata\NewsBundle\Form\Type\CommentStatusType',
-            'sonata_news_api_form_comment' => 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType',
-            'sonata_news_api_form_post' => 'Sonata\CoreBundle\Form\Type\DoctrineORMSerializationType',
+            'sonata_news_api_form_comment' => 'Sonata\NewsBundle\Form\Type\ApiCommentType',
+            'sonata_news_api_form_post' => 'Sonata\NewsBundle\Form\Type\ApiPostType',
         ));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is the stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- add missing configuration to make the CoreBundle's FormHelper works properly
```

## Subject

<!-- Describe your Pull Request content here -->

Fix missing code to make the FormHelper works properly, this affect the sonata's REST API.