### PR TITLE
Add BlockBundle config instructions and removing obsolete MarkItUpBun…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.* export-ignore
+*.md export-ignore
+Tests/* export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->
+<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
 
 <!--
     Show us you choose the right branch.
@@ -7,15 +7,14 @@
     - master is for deprecation removals and other changes that cannot be done without a BC-break
     More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
 -->
-I am targetting this branch, because…
+I am targetting this branch, because {reason}.
 
 <!--
     Specify which issues will be fixed/closed.
     Remove it if this is not related.
 -->
 
-Closes #
-Fixes #
+Closes #{put_issue_number_here}
 
 ## Changelog
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-.idea
-.DS_Store
-build
-phpunit.xml
-Resources/doc/_build/*
-nbproject
-coverage
-composer.lock
-vendor
+/build
+/Resources/doc/_build/
+/vendor
 .php_cs.cache
+composer.lock
+phpunit.xml

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,6 +7,7 @@
 preset: symfony
 
 enabled:
+  - class_keyword_remove
   - combine_consecutive_unsets
   - long_array_syntax
   - newline_after_open_tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ branches:
 language: php
 
 php:
-  - '5.3'
-  - '5.4'
-  - '5.5'
   - '5.6'
   - '7.0'
   - nightly
@@ -40,12 +37,8 @@ matrix:
       env: TARGET=docs
     - php: '7.0'
       env: TARGET=lint
-    - php: '5.3'
+    - php: '5.6'
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '7.0'
-      env: SYMFONY=2.3.*
-    - php: '7.0'
-      env: SYMFONY=2.7.*
     - php: '7.0'
       env: SYMFONY=2.8.*
     - php: '7.0'

--- a/.travis/install_docs.sh
+++ b/.travis/install_docs.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -ev
 
-pip install -r Resources/doc/requirements.txt --user $(whoami)
+pip install -r Resources/doc/requirements.txt --user

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,9 +181,9 @@ namespace Foo;
 
 interface BarInterface
 {
-
-  // NEXT_MAJOR: Uncomment this method
   /**
+   * NEXT_MAJOR: Uncomment this method
+   *
    * This method does useful stuff.
    */
   // public function usefulMethod();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,21 @@ if (/* some condition showing the user is using the legacy way */) {
 }
 ```
 
+Additionally, and when applicable, you must use the `@deprecated` tag on classes or methods you wish to deprecate,
+along with a message directed at the end user (as opposed to other contributors).
+
+
+```php
+/**
+ * NEXT_MAJOR: remove this method
+ *
+ * @deprecated since 3.x, to be removed in 4.0. Use Foo::bar instead.
+ */
+public function baz()
+{
+}
+```
+
 In that case, unit tests might show your deprecation notice. You must mark such tests with the `@group legacy` annotation,
 and if need be, isolate them in a new test method that can simply be removed in the non-BC PR.
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -5,17 +5,14 @@ Installation
 
 .. code-block:: bash
 
-    composer require sonata-project/news-bundle "dev-master" --no-update
-    composer require sonata-project/doctrine-orm-admin-bundle "dev-master" --no-update
-    composer require sonata-project/easy-extends-bundle "dev-master" --no-update
-    composer require friendsofsymfony/rest-bundle "~1.1" --no-update
-    composer require nelmio/api-doc-bundle "~0.1|~1.0" --no-update
-    composer require sonata-project/classification-bundle "~2.2@dev"
+    composer require sonata-project/news-bundle sonata-project/doctrine-orm-admin-bundle
 
 
-``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle`` are needed only
-if you use the API.
+If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``.
 
+.. code-block:: bash
+
+    composer require nelmio/api-doc-bundle friendsofsymfony/rest-bundle
 
 * Add SonataNewsBundle to your application kernel:
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -28,7 +28,6 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
         return array(
             // ...
             new Sonata\CoreBundle\SonataCoreBundle(),
-            new Sonata\MarkItUpBundle\SonataMarkItUpBundle(),
             new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
             new Sonata\NewsBundle\SonataNewsBundle(),
             new Sonata\UserBundle\SonataUserBundle(),
@@ -43,6 +42,7 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
             new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
             new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
+            new Sonata\BlockBundle\SonataBlockBundle(),
         );
     }
 
@@ -78,24 +78,7 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
                         SonataNewsBundle: ~
 
 
-* Import the ``sonata_news.yml`` file and enable json type for doctrine:
-
-.. code-block:: yaml
-
-    # app/config/config.yml
-
-    imports:
-        # ...
-        - { resource: sonata_news.yml }
-    # ...
-    doctrine:
-        dbal:
-        # ...
-            types:
-                json: Sonata\Doctrine\Types\JsonType
-
-
-* Add a new context into your ``sonata_media.yml`` configuration if you don't have go there https://sonata-project.org/bundles/media/master/doc/reference/installation.html:
+* Add a new context into your ``sonata_media.yml`` configuration. See `Sonata Media Bundle Configuration`_ for detailed instructions:
 
 .. code-block:: yaml
 
@@ -111,8 +94,8 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
             small: { width: 150 , quality: 95}
             big:   { width: 500 , quality: 90}
 
-* Create configuration file ``sonata_formatter.yml`` the text formatters available for your blog post:
 
+* Create configuration file ``sonata_formatter.yml`` the text formatters available for your blog post:
 
 .. code-block:: yaml
 
@@ -148,6 +131,47 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
                     - sonata.formatter.twig.gist
                     - sonata.media.formatter.twig
 
+* Create configuration file ``sonata_block.yml`` for block rendering as per Configuration_:
+
+.. code-block:: yaml
+
+    # app/config/sonata_block.yml
+
+    sonata_block:
+        default_contexts: [sonata_page_bundle]
+        blocks:
+            sonata.admin.block.admin_list:
+                contexts:   [admin]
+
+            #sonata.admin_doctrine_orm.block.audit:
+            #    contexts:   [admin]
+
+            sonata.block.service.text:
+            sonata.block.service.rss:
+
+            # Some specific block from the SonataMediaBundle
+            sonata.media.block.media:
+            sonata.media.block.gallery:
+            sonata.media.block.feature_media:
+
+* Import the above sonata config files and enable json type for doctrine:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    imports:
+        # ...
+        - { resource: sonata_news.yml }
+        - { resource: sonata_media.yml }
+        - { resource: sonata_formatter.yml }
+        - { resource: sonata_block.yml }
+    # ...
+    doctrine:
+        dbal:
+        # ...
+            types:
+                json: Sonata\Doctrine\Types\JsonType
 
 * Generate the application bundles:
 
@@ -210,3 +234,5 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
         resource: '@SonataNewsBundle/Resources/config/routing/news.xml'
         prefix: /news
 
+.. _Configuration: https://sonata-project.org/bundles/block/master/doc/reference/installation.html
+.. _Sonata Media Bundle Configuration: https://sonata-project.org/bundles/media/master/doc/reference/installation.htm

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sonata-project/easy-extends-bundle": "^2.1",
         "sonata-project/intl-bundle": "^2.2.4",
         "sonata-project/datagrid-bundle": "^2.2",
-        "sonata-project/core-bundle": "^3.0"
+        "sonata-project/core-bundle": "^3.0.2"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because i have seen doc updates pointing to master

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #338 
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown

### Changed
- Installation instructions for the BlockBundle dependency
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the documentation
## Subject

Add missing step to configure the BlockBundle and remove obsolete MarkItUp Bundle reference
