### PR TITLE
Improved extensibility of controller actions

### DIFF
--- a/Controller/Api/CommentController.php
+++ b/Controller/Api/CommentController.php
@@ -60,13 +60,12 @@ class CommentController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int $id A comment identifier
+     * @param Request $request
+     * @param int     $id A comment identifier
      *
      * @return Comment
-     *
-     * @throws NotFoundHttpException
      */
-    public function getCommentAction($id)
+    public function getCommentAction(Request $request, $id)
     {
         return $this->getComment($id);
     }
@@ -87,13 +86,12 @@ class CommentController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int $id A comment identifier
+     * @param Request $request
+     * @param int     $id A comment identifier
      *
      * @return View
-     *
-     * @throws NotFoundHttpException
      */
-    public function deleteCommentAction($id)
+    public function deleteCommentAction(Request $request, $id)
     {
         $comment = $this->getComment($id);
 

--- a/Controller/Api/PostController.php
+++ b/Controller/Api/PostController.php
@@ -102,11 +102,12 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
+     * @param Request               $request
      * @param ParamFetcherInterface $paramFetcher
      *
      * @return PagerInterface
      */
-    public function getPostsAction(ParamFetcherInterface $paramFetcher)
+    public function getPostsAction(Request $request, ParamFetcherInterface $paramFetcher)
     {
         $page = $paramFetcher->get('page');
         $count = $paramFetcher->get('count');
@@ -134,11 +135,12 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int $id A post identifier
+     * @param Request $request
+     * @param int     $id A post identifier
      *
      * @return Post
      */
-    public function getPostAction($id)
+    public function getPostAction(Request $request, $id)
     {
         return $this->getPost($id);
     }
@@ -186,14 +188,14 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int     $id      A Post identifier
      * @param Request $request A Symfony request
+     * @param int     $id      A Post identifier
      *
      * @return Post
      *
      * @throws NotFoundHttpException
      */
-    public function putPostAction($id, Request $request)
+    public function putPostAction(Request $request, $id)
     {
         return $this->handleWritePost($request, $id);
     }
@@ -214,13 +216,12 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int $id A Post identifier
+     * @param Request $request
+     * @param int     $id A Post identifier
      *
      * @return View
-     *
-     * @throws NotFoundHttpException
      */
-    public function deletePostAction($id)
+    public function deletePostAction(Request $request, $id)
     {
         $post = $this->getPost($id);
 
@@ -254,12 +255,13 @@ class PostController
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @param int                   $id           A post identifier
+     * @param Request               $request
+     * @param int                   $id A post identifier
      * @param ParamFetcherInterface $paramFetcher
      *
      * @return PagerInterface
      */
-    public function getPostCommentsAction($id, ParamFetcherInterface $paramFetcher)
+    public function getPostCommentsAction(Request $request, $id, ParamFetcherInterface $paramFetcher)
     {
         $post = $this->getPost($id);
 
@@ -294,14 +296,14 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
-     * @param int     $id      A post identifier
      * @param Request $request
+     * @param int     $id      A post identifier
      *
      * @return Comment|FormInterface
      *
      * @throws HttpException
      */
-    public function postPostCommentsAction($id, Request $request)
+    public function postPostCommentsAction(Request $request, $id)
     {
         $post = $this->getPost($id);
 
@@ -357,16 +359,16 @@ class PostController
      *
      * @Route(requirements={"_format"="json|xml"})
      *
+     * @param Request $request   A Symfony request
      * @param int     $postId    A post identifier
      * @param int     $commentId A comment identifier
-     * @param Request $request   A Symfony request
      *
      * @return Comment
      *
      * @throws NotFoundHttpException
      * @throws HttpException
      */
-    public function putPostCommentsAction($postId, $commentId, Request $request)
+    public function putPostCommentsAction(Request $request, $postId, $commentId)
     {
         $post = $this->getPost($postId);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `$request` parameter to all controller actions
```
## Subject

Improved extensibility of controller actions by injection the `$request` parameter by default.
