### PR TITLE
Recommend stable versions

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -5,8 +5,7 @@ Installation
 
 .. code-block:: bash
 
-    composer require sonata-project/news-bundle "dev-master" --no-update
-    composer require sonata-project/doctrine-orm-admin-bundle "dev-master" --no-update
+    composer require sonata-project/news-bundle sonata-project/doctrine-orm-admin-bundle
 
 
 If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``.

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -7,10 +7,8 @@ Installation
 
     composer require sonata-project/news-bundle "dev-master" --no-update
     composer require sonata-project/doctrine-orm-admin-bundle "dev-master" --no-update
-    composer require sonata-project/easy-extends-bundle "dev-master" --no-update
     composer require friendsofsymfony/rest-bundle "~1.1" --no-update
     composer require nelmio/api-doc-bundle "~0.1|~1.0" --no-update
-    composer require sonata-project/classification-bundle "~2.2@dev"
 
 
 ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle`` are needed only

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -7,13 +7,13 @@ Installation
 
     composer require sonata-project/news-bundle "dev-master" --no-update
     composer require sonata-project/doctrine-orm-admin-bundle "dev-master" --no-update
-    composer require friendsofsymfony/rest-bundle "~1.1" --no-update
-    composer require nelmio/api-doc-bundle "~0.1|~1.0" --no-update
 
 
-``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle`` are needed only
-if you use the API.
+If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``.
 
+.. code-block:: bash
+
+    composer require nelmio/api-doc-bundle friendsofsymfony/rest-bundle
 
 * Add SonataNewsBundle to your application kernel:
 


### PR DESCRIPTION
I am targetting this branch, because this is about documentation

## Subject

See http://stackoverflow.com/questions/40206041/install-sonata-news-bundle-composer-error

The optional instructions still do not work, but at least the basic bundle can be installed.