### PR TITLE
Allow null result for PostManager::findOneBySlug

### DIFF
--- a/Document/PostManager.php
+++ b/Document/PostManager.php
@@ -26,7 +26,7 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
      * @param $day
      * @param $slug
      *
-     * @return mixed
+     * @return PostInterface|null
      *
      * @deprecated since version 3.x, to be removed in 4.0. Use PostManager::findOneByPermalink instead
      */
@@ -39,14 +39,14 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
             ->field('slug')->equals($slug)
             ->andWhere($pdqp['query'])
             ->getQuery()
-            ->getSingleResult();
+            ->getOneOrNullResult();
     }
 
     /**
      * @param string        $permalink
      * @param BlogInterface $blog
      *
-     * @return PostInterface
+     * @return PostInterface|null
      */
     public function findOneByPermalink($permalink, BlogInterface $blog)
     {
@@ -88,7 +88,7 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
 
         $query->setParameters($parameters);
 
-        return $query->getQuery()->getSingleResult();
+        return $query->getQuery()->getOneOrNullResult();
     }
 
     /**

--- a/Entity/PostManager.php
+++ b/Entity/PostManager.php
@@ -26,7 +26,7 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
      * @param string        $permalink
      * @param BlogInterface $blog
      *
-     * @return PostInterface
+     * @return PostInterface|null
      */
     public function findOneByPermalink($permalink, BlogInterface $blog)
     {
@@ -68,7 +68,7 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
 
         $query->setParameters($parameters);
 
-        return $query->getQuery()->getSingleResult();
+        return $query->getQuery()->getOneOrNullResult();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- the method `PostManager::findOneBySlug` will return null if the permalink couldn't be found

### Fixed
- Fixed throwing doctrine exception on invalid permalink
```

## Subject

If you try to call the view action in the [PostController](https://github.com/sonata-project/SonataNewsBundle/blob/3.x/Controller/PostController.php#L171), it will throw a `Doctrine\ORM\NoResultException` if the permalink is invalid or could not been found., so the null check in the same method will never be called.



