### PR TITLE
Some fixes

### DIFF
--- a/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
+++ b/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
@@ -30,6 +30,14 @@ class NewsPostBreadcrumbBlockService extends BaseNewsBreadcrumbBlockService
      */
     protected $blog;
 
+    /**
+     * @param string                $context
+     * @param string                $name
+     * @param EngineInterface       $templating
+     * @param MenuProviderInterface $menuProvider
+     * @param FactoryInterface      $factory
+     * @param BlogInterface         $blog
+     */
     public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, BlogInterface $blog)
     {
         $this->blog = $blog;

--- a/Block/RecentPostsBlockService.php
+++ b/Block/RecentPostsBlockService.php
@@ -34,6 +34,11 @@ class RecentPostsBlockService extends AbstractAdminBlockService
     protected $manager;
 
     /**
+     * @var Pool
+     */
+    private $adminPool;
+
+    /**
      * @param string           $name
      * @param EngineInterface  $templating
      * @param ManagerInterface $postManager

--- a/Command/SynchronizeCommentsCountCommand.php
+++ b/Command/SynchronizeCommentsCountCommand.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\NewsBundle\Command;
 
-use Sonata\NewsBundle\Model\Comment;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Controller/Api/CommentController.php
+++ b/Controller/Api/CommentController.php
@@ -84,7 +84,7 @@ class CommentController
      *
      * @param int $id A comment identifier
      *
-     * @return View
+     * @return \FOS\RestBundle\View\View
      *
      * @throws NotFoundHttpException
      */

--- a/Controller/Api/CommentController.php
+++ b/Controller/Api/CommentController.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\NewsBundle\Controller\Api;
 
-use FOS\RestBundle\Controller\Annotations\Route;
-use FOS\RestBundle\Controller\Annotations\View;
+use FOS\RestBundle\Controller\Annotations as REST;
+use FOS\RestBundle\View\View;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\NewsBundle\Model\Comment;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
@@ -51,9 +51,9 @@ class CommentController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int $id A comment identifier
      *
@@ -80,11 +80,11 @@ class CommentController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int $id A comment identifier
      *
-     * @return \FOS\RestBundle\View\View
+     * @return View
      *
      * @throws NotFoundHttpException
      */
@@ -95,7 +95,7 @@ class CommentController
         try {
             $this->commentManager->delete($comment);
         } catch (\Exception $e) {
-            return \FOS\RestBundle\View\View::create(array('error' => $e->getMessage()), 400);
+            return View::create(array('error' => $e->getMessage()), 400);
         }
 
         return array('deleted' => true);

--- a/Controller/Api/PostController.php
+++ b/Controller/Api/PostController.php
@@ -12,10 +12,9 @@
 namespace Sonata\NewsBundle\Controller\Api;
 
 use Application\Sonata\NewsBundle\Entity\Post;
-use FOS\RestBundle\Controller\Annotations\QueryParam;
-use FOS\RestBundle\Controller\Annotations\Route;
-use FOS\RestBundle\Controller\Annotations\View;
+use FOS\RestBundle\Controller\Annotations as REST;
 use FOS\RestBundle\Request\ParamFetcherInterface;
+use FOS\RestBundle\View\View;
 use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
@@ -84,18 +83,18 @@ class PostController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
-     * @QueryParam(name="page", requirements="\d+", default="1", description="Page for posts list pagination")
-     * @QueryParam(name="count", requirements="\d+", default="10", description="Number of posts by page")
-     * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled posts filter")
-     * @QueryParam(name="dateQuery", requirements=">|<|=", default=">", description="Date filter orientation (>, < or =)")
-     * @QueryParam(name="dateValue", requirements="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]([+-][0-9]{2}(:)?[0-9]{2})?", nullable=true, strict=true, description="Date filter value")
-     * @QueryParam(name="tag", requirements="\S+", nullable=true, strict=true, description="Tag name filter")
-     * @QueryParam(name="author", requirements="\S+", nullable=true, strict=true, description="Author filter")
-     * @QueryParam(name="mode", requirements="public|admin", default="public", description="'public' mode filters posts having enabled tags and author")
+     * @REST\QueryParam(name="page", requirements="\d+", default="1", description="Page for posts list pagination")
+     * @REST\QueryParam(name="count", requirements="\d+", default="10", description="Number of posts by page")
+     * @REST\QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled posts filter")
+     * @REST\QueryParam(name="dateQuery", requirements=">|<|=", default=">", description="Date filter orientation (>, < or =)")
+     * @REST\QueryParam(name="dateValue", requirements="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]([+-][0-9]{2}(:)?[0-9]{2})?", nullable=true, strict=true, description="Date filter value")
+     * @REST\QueryParam(name="tag", requirements="\S+", nullable=true, strict=true, description="Tag name filter")
+     * @REST\QueryParam(name="author", requirements="\S+", nullable=true, strict=true, description="Author filter")
+     * @REST\QueryParam(name="mode", requirements="public|admin", default="public", description="'public' mode filters posts having enabled tags and author")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -125,9 +124,9 @@ class PostController
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int $id A post identifier
      *
@@ -150,7 +149,7 @@ class PostController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param Request $request A Symfony request
      *
@@ -179,7 +178,7 @@ class PostController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int     $id      A Post identifier
      * @param Request $request A Symfony request
@@ -207,11 +206,11 @@ class PostController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int $id A Post identifier
      *
-     * @return \FOS\RestBundle\View\View
+     * @return View
      *
      * @throws NotFoundHttpException
      */
@@ -222,7 +221,7 @@ class PostController
         try {
             $this->postManager->delete($post);
         } catch (\Exception $e) {
-            return \FOS\RestBundle\View\View::create(array('error' => $e->getMessage()), 400);
+            return View::create(array('error' => $e->getMessage()), 400);
         }
 
         return array('deleted' => true);
@@ -242,12 +241,12 @@ class PostController
      *  }
      * )
      *
-     * @QueryParam(name="page", requirements="\d+", default="1", description="Page for comments list pagination")
-     * @QueryParam(name="count", requirements="\d+", default="10", description="Number of comments by page")
+     * @REST\QueryParam(name="page", requirements="\d+", default="1", description="Page for comments list pagination")
+     * @REST\QueryParam(name="count", requirements="\d+", default="10", description="Number of comments by page")
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
      * @param int                   $id           A post identifier
      * @param ParamFetcherInterface $paramFetcher
@@ -287,7 +286,7 @@ class PostController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int     $id      A post identifier
      * @param Request $request
@@ -321,7 +320,7 @@ class PostController
             $this->commentManager->save($comment);
             $this->mailer->sendCommentNotification($comment);
 
-            $view = \FOS\RestBundle\View\View::create($comment);
+            $view = View::create($comment);
             $serializationContext = SerializationContext::create();
             $serializationContext->setGroups(array('sonata_api_read'));
             $serializationContext->enableMaxDepthChecks();
@@ -350,7 +349,7 @@ class PostController
      *  }
      * )
      *
-     * @Route(requirements={"_format"="json|xml"})
+     * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int     $postId    A post identifier
      * @param int     $commentId A comment identifier
@@ -387,7 +386,7 @@ class PostController
             $comment = $form->getData();
             $this->commentManager->save($comment);
 
-            $view = \FOS\RestBundle\View\View::create($comment);
+            $view = View::create($comment);
             $serializationContext = SerializationContext::create();
             $serializationContext->setGroups(array('sonata_api_read'));
             $serializationContext->enableMaxDepthChecks();
@@ -475,7 +474,7 @@ class PostController
             $post->setContent($this->formatterPool->transform($post->getContentFormatter(), $post->getRawContent()));
             $this->postManager->save($post);
 
-            $view = \FOS\RestBundle\View\View::create($post);
+            $view = View::create($post);
             $serializationContext = SerializationContext::create();
             $serializationContext->setGroups(array('sonata_api_read'));
             $serializationContext->enableMaxDepthChecks();

--- a/Controller/Api/PostController.php
+++ b/Controller/Api/PostController.php
@@ -211,7 +211,7 @@ class PostController
      *
      * @param int $id A Post identifier
      *
-     * @return View
+     * @return \FOS\RestBundle\View\View
      *
      * @throws NotFoundHttpException
      */

--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -105,7 +105,7 @@ class PostController extends Controller
     }
 
     /**
-     * @param $collection
+     * @param string  $collection
      * @param Request $request
      *
      * @return Response
@@ -162,7 +162,7 @@ class PostController extends Controller
     /**
      * @throws NotFoundHttpException
      *
-     * @param $permalink
+     * @param string $permalink
      *
      * @return Response
      */
@@ -247,7 +247,7 @@ class PostController extends Controller
     }
 
     /**
-     * @param $post
+     * @param PostInterface $post
      *
      * @return FormInterface
      */

--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -181,7 +181,7 @@ class PostController extends Controller
                 ->addMeta('property', 'og:title', $post->getTitle())
                 ->addMeta('property', 'og:type', 'blog')
                 ->addMeta('property', 'og:url', $this->generateUrl('sonata_news_view', array(
-                    'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post, true),
+                    'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post),
                 ), UrlGeneratorInterface::ABSOLUTE_URL))
                 ->addMeta('property', 'og:description', $post->getAbstract())
             ;

--- a/Controller/PostController.php
+++ b/Controller/PostController.php
@@ -195,7 +195,7 @@ class PostController extends Controller
     }
 
     /**
-     * @return SeoPageInterface
+     * @return SeoPageInterface|null
      */
     public function getSeoPage()
     {
@@ -203,7 +203,7 @@ class PostController extends Controller
             return $this->get('sonata.seo.page');
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/DependencyInjection/SonataNewsExtension.php
+++ b/DependencyInjection/SonataNewsExtension.php
@@ -93,7 +93,7 @@ class SonataNewsExtension extends Extension
                 'notification' => $config['comment']['notification'],
             ));
 
-        $this->registerDoctrineMapping($config, $container);
+        $this->registerDoctrineMapping($config);
         $this->configureClass($config, $container);
         $this->configureAdmin($config, $container);
     }

--- a/Document/BasePost.php
+++ b/Document/BasePost.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\NewsBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\NewsBundle\Model\Post as ModelPost;
 
 abstract class BasePost extends ModelPost
@@ -20,7 +21,7 @@ abstract class BasePost extends ModelPost
      */
     public function __construct()
     {
-        $this->tags = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->tags = new ArrayCollection();
+        $this->comments = new ArrayCollection();
     }
 }

--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -26,7 +26,7 @@ class CommentManager extends BaseDocumentManager implements CommentManagerInterf
      * @param int   $limit
      * @param array $sort
      *
-     * @return \Sonata\AdminBundle\Datagrid\ODM\Pager
+     * @return Pager
      */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
     {
@@ -52,7 +52,7 @@ class CommentManager extends BaseDocumentManager implements CommentManagerInterf
     /**
      * Update the comments count.
      *
-     * @param \Sonata\NewsBundle\Model\PostInterface $post
+     * @param PostInterface $post
      */
     public function updateCommentsCount(PostInterface $post = null)
     {

--- a/Document/CommentManager.php
+++ b/Document/CommentManager.php
@@ -30,8 +30,6 @@ class CommentManager extends BaseDocumentManager implements CommentManagerInterf
      */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = array())
     {
-        $parameters = array();
-
         $qb = $this->getDocumentManager()->getRepository($this->class)
             ->createQueryBuilder()
             ->sort('createdAt', 'desc');

--- a/Document/PostManager.php
+++ b/Document/PostManager.php
@@ -89,7 +89,7 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
         }
 
         if (count($parameters) == 0) {
-            return;
+            return null;
         }
 
         $query->setParameters($parameters);

--- a/Entity/BasePostRepository.php
+++ b/Entity/BasePostRepository.php
@@ -12,6 +12,7 @@
 namespace Sonata\NewsBundle\Entity;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 
 class BasePostRepository extends EntityRepository
 {
@@ -32,9 +33,9 @@ class BasePostRepository extends EntityRepository
     /**
      * return count comments QueryBuilder.
      *
-     * @param  Sonata\NewsBundle\Model\PostInterface
+     * @param  PostInterface
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function countCommentsQuery($post)
     {

--- a/Entity/PostManager.php
+++ b/Entity/PostManager.php
@@ -63,7 +63,7 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
         }
 
         if (count($parameters) == 0) {
-            return;
+            return null;
         }
 
         $query->setParameters($parameters);

--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -51,6 +51,7 @@ class Mailer implements MailerInterface
 
     /**
      * @param \Swift_Mailer          $mailer
+     * @param BlogInterface          $blog
      * @param HashGeneratorInterface $generator
      * @param RouterInterface        $router
      * @param EngineInterface        $templating

--- a/Model/Blog.php
+++ b/Model/Blog.php
@@ -15,10 +15,19 @@ use Sonata\NewsBundle\Permalink\PermalinkInterface;
 
 class Blog implements BlogInterface
 {
+    /**
+     * @var string
+     */
     protected $title;
 
+    /**
+     * @var string
+     */
     protected $link;
 
+    /**
+     * @var string
+     */
     protected $description;
 
     /**

--- a/Model/Comment.php
+++ b/Model/Comment.php
@@ -65,7 +65,7 @@ abstract class Comment implements CommentInterface
     /**
      * Post for which the comment is related to.
      *
-     * @var \Sonata\NewsBundle\Model\PostInterface
+     * @var PostInterface
      */
     protected $post;
 

--- a/Model/CommentInterface.php
+++ b/Model/CommentInterface.php
@@ -127,14 +127,14 @@ interface CommentInterface
     /**
      * Set post.
      *
-     * @param \Sonata\NewsBundle\Model\PostInterface $post
+     * @param PostInterface $post
      */
     public function setPost($post);
 
     /**
      * Get post.
      *
-     * @return \Sonata\NewsBundle\Model\PostInterface $post
+     * @return PostInterface $post
      */
     public function getPost();
 }

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -12,48 +12,108 @@
 namespace Sonata\NewsBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use FOS\UserBundle\Model\UserInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\Tag;
 use Sonata\ClassificationBundle\Model\TagInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 abstract class Post implements PostInterface
 {
+    /**
+     * @var string
+     */
     protected $title;
 
+    /**
+     * @var string
+     */
     protected $slug;
 
+    /**
+     * @var string
+     */
     protected $abstract;
 
+    /**
+     * @var string
+     */
     protected $content;
 
+    /**
+     * @var string
+     */
     protected $rawContent;
 
+    /**
+     * @var string
+     */
     protected $contentFormatter;
 
+    /**
+     * @var Collection|TagInterface[]
+     */
     protected $tags;
 
+    /**
+     * @var Collection|CommentInterface[]
+     */
     protected $comments;
 
+    /**
+     * @var bool
+     */
     protected $enabled;
 
+    /**
+     * @var \DateTime
+     */
     protected $publicationDateStart;
 
+    /**
+     * @var \DateTime
+     */
     protected $createdAt;
 
+    /**
+     * @var \DateTime
+     */
     protected $updatedAt;
 
+    /**
+     * @var bool
+     */
     protected $commentsEnabled = true;
 
+    /**
+     * @var \DateTime
+     */
     protected $commentsCloseAt;
 
+    /**
+     * @var int
+     */
     protected $commentsDefaultStatus;
 
+    /**
+     * @var int
+     */
     protected $commentsCount = 0;
 
+    /**
+     * @var UserInterface
+     */
     protected $author;
 
+    /**
+     * @var MediaInterface
+     */
     protected $image;
 
+    /**
+     * @var Collection|CollectionInterface[]
+     */
     protected $collection;
 
     /**

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\NewsBundle\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\Tag;
 use Sonata\ClassificationBundle\Model\TagInterface;
@@ -215,7 +216,7 @@ abstract class Post implements PostInterface
      */
     public function setComments($comments)
     {
-        $this->comments = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->comments = new ArrayCollection();
 
         foreach ($this->comments as $comment) {
             $this->addComments($comment);

--- a/Model/PostInterface.php
+++ b/Model/PostInterface.php
@@ -11,13 +11,16 @@
 
 namespace Sonata\NewsBundle\Model;
 
+use Doctrine\Common\Collections\Collection;
+use FOS\UserBundle\Model\UserInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 interface PostInterface
 {
     /**
-     * @return mixed
+     * @return int
      */
     public function getId();
 
@@ -80,14 +83,14 @@ interface PostInterface
     /**
      * Set slug.
      *
-     * @param int $slug
+     * @param string $slug
      */
     public function setSlug($slug);
 
     /**
      * Get slug.
      *
-     * @return int $slug
+     * @return string $slug
      */
     public function getSlug();
 
@@ -141,14 +144,14 @@ interface PostInterface
     public function addComments(CommentInterface $comments);
 
     /**
-     * @param array $comments
+     * @param Collection|CommentInterface[] $comments
      */
     public function setComments($comments);
 
     /**
      * Get comments.
      *
-     * @return array $comments
+     * @return Collection|CommentInterface[] $comments
      */
     public function getComments();
 
@@ -162,14 +165,12 @@ interface PostInterface
     /**
      * Get tags.
      *
-     * @return array $tags
+     * @return Collection|TagInterface[] $tags
      */
     public function getTags();
 
     /**
-     * @param $tags
-     *
-     * @return mixed
+     * @param Collection|TagInterface[]$tags
      */
     public function setTags($tags);
 
@@ -255,26 +256,22 @@ interface PostInterface
     public function isPublic();
 
     /**
-     * @param mixed $author
-     *
-     * @return mixed
+     * @param UserInterface $author
      */
     public function setAuthor($author);
 
     /**
-     * @return mixed
+     * @return UserInterface
      */
     public function getAuthor();
 
     /**
-     * @param mixed $image
-     *
-     * @return mixed
+     * @param MediaInterface $image
      */
     public function setImage($image);
 
     /**
-     * @return mixed
+     * @return MediaInterface
      */
     public function getImage();
 

--- a/Status/CommentStatusRenderer.php
+++ b/Status/CommentStatusRenderer.php
@@ -35,13 +35,10 @@ class CommentStatusRenderer implements StatusClassRendererInterface
         switch ($object->getStatus()) {
             case CommentInterface::STATUS_INVALID:
                 return 'danger';
-                break;
             case CommentInterface::STATUS_MODERATE:
                 return 'warning';
-                break;
             case CommentInterface::STATUS_VALID:
                 return 'success';
-                break;
             default:
                 break;
         }

--- a/Status/CommentStatusRenderer.php
+++ b/Status/CommentStatusRenderer.php
@@ -40,7 +40,7 @@ class CommentStatusRenderer implements StatusClassRendererInterface
             case CommentInterface::STATUS_VALID:
                 return 'success';
             default:
-                break;
+                return null;
         }
     }
 }

--- a/Tests/Model/BaseModelTest.php
+++ b/Tests/Model/BaseModelTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Model\Post;
 use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
-class BasePostTest_Post extends \Sonata\NewsBundle\Model\Post
+class BasePostTest_Post extends Post
 {
     public function getId()
     {

--- a/Tests/Model/CommentTest.php
+++ b/Tests/Model/CommentTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Model\Comment;
 use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
-class ModelTest_Comment extends \Sonata\NewsBundle\Model\Comment
+class ModelTest_Comment extends Comment
 {
     public function getId()
     {

--- a/Tests/Model/PostTest.php
+++ b/Tests/Model/PostTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Model\Post;
 use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
-class ModelTest_Post extends \Sonata\NewsBundle\Model\Post
+class ModelTest_Post extends Post
 {
     public function getId()
     {

--- a/Twig/Extension/NewsExtension.php
+++ b/Twig/Extension/NewsExtension.php
@@ -118,7 +118,7 @@ class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     /**
      * @param PostInterface $post
      *
-     * @return string|Exception
+     * @return string
      */
     public function generatePermalink(PostInterface $post)
     {

--- a/Twig/Extension/NewsExtension.php
+++ b/Twig/Extension/NewsExtension.php
@@ -36,6 +36,11 @@ class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     private $environment;
 
     /**
+     * @var BlogInterface
+     */
+    private $blog;
+
+    /**
      * @param RouterInterface  $router
      * @param ManagerInterface $tagManager
      * @param BlogInterface    $blog


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this are pedantic changes.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added missing `RecentPostsBlockService::$adminPool` parameter
- Added missing `NewsExtension::$blog` parameter

### Removed
 - Removed dead parameters in method calls

### Fixed
 - Fixed wrong or missing PHPDoc
 - Fixed return null value instead of void in `PostController::getSeoPage`
 - Fixed return null value instead of void in `PostManager::findOneByPermalink`
 - Fixed return null value instead of void in `CommentStatusRenderer::getStatusClass`
```

## Subject

Fixed some pedantic stuff.
