### PR TITLE
Added missing swift mailer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "sonata-project/easy-extends-bundle": "^2.1",
         "sonata-project/intl-bundle": "^2.2.4",
         "sonata-project/datagrid-bundle": "^2.2.1",
-        "sonata-project/core-bundle": "^3.0"
+        "sonata-project/core-bundle": "^3.0",
+        "swiftmailer/swiftmailer": "^4.3 || ^5.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added missing swiftmailer dependency
```

## Subject

This classed is used here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/Mailer/Mailer.php#L43
