### PR TITLE
Catch exception when finding post by permalink

### DIFF
--- a/Document/PostManager.php
+++ b/Document/PostManager.php
@@ -58,7 +58,11 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
     {
         $query = $this->getRepository()->createQueryBuilder('p');
 
-        $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
+        try {
+            $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
+        } catch (\InvalidArgumentException $exception) {
+            return null;
+        }
 
         $parameters = array();
 

--- a/Entity/PostManager.php
+++ b/Entity/PostManager.php
@@ -32,7 +32,11 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
     {
         $query = $this->getRepository()->createQueryBuilder('p');
 
-        $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
+        try {
+            $urlParameters = $blog->getPermalinkGenerator()->getParameters($permalink);
+        } catch (\InvalidArgumentException $exception) {
+            return null;
+        }
 
         $parameters = array();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Catch exception when finding post by permalink

```

## Subject

According to the [PermalinkInterace](https://github.com/sonata-project/SonataNewsBundle/blob/3.x/Permalink/PermalinkInterface.php#L28) an exception could occur. This PR catches the exception so a PostInterface or null will be returns when calling `PostManager::findOneByPermalink`.
