### PR TITLE
Removed deprecated getMock in unit tests

### DIFF
--- a/Tests/Controller/Api/CommentControllerTest.php
+++ b/Tests/Controller/Api/CommentControllerTest.php
@@ -12,17 +12,18 @@
 namespace Sonata\NewsBundle\Tests\Controller\Api;
 
 use Sonata\NewsBundle\Controller\Api\CommentController;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class CommentControllerTest extends \PHPUnit_Framework_TestCase
+class CommentControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetCommentAction()
     {
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
 
         $this->assertEquals($comment, $this->createCommentController($commentManager)->getCommentAction(1));
@@ -39,9 +40,9 @@ class CommentControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteCommentAction()
     {
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
         $commentManager->expects($this->once())->method('delete');
 
@@ -54,7 +55,7 @@ class CommentControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $commentManager->expects($this->never())->method('delete');
 
@@ -69,7 +70,7 @@ class CommentControllerTest extends \PHPUnit_Framework_TestCase
     protected function createCommentController($commentManager = null)
     {
         if (null === $commentManager) {
-            $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+            $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         }
 
         return new CommentController($commentManager);

--- a/Tests/Controller/Api/PostControllerTest.php
+++ b/Tests/Controller/Api/PostControllerTest.php
@@ -12,21 +12,22 @@
 namespace Sonata\NewsBundle\Tests\Controller\Api;
 
 use Sonata\NewsBundle\Controller\Api\PostController;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class PostControllerTest extends \PHPUnit_Framework_TestCase
+class PostControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPostsAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $pager = $this->getMock('Sonata\DatagridBundle\Pager\PagerInterface');
+        $pager = $this->createMock('Sonata\DatagridBundle\Pager\PagerInterface');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $this->assertSame($pager, $this->createPostController($postManager)->getPostsAction($paramFetcher));
@@ -34,9 +35,9 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPostAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
         $this->assertEquals($post, $this->createPostController($postManager)->getPostAction(1));
@@ -58,7 +59,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
             'count' => 5,
         );
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
         $paramFetcher->expects($this->exactly(2))->method('get')
             ->with($this->logicalOr($this->equalTo('page'), $this->equalTo('count')))
@@ -66,15 +67,15 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
                 return $parameters[$parameter];
             }));
 
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
-        $pager = $this->getMock('Sonata\DatagridBundle\Pager\PagerInterface');
+        $pager = $this->createMock('Sonata\DatagridBundle\Pager\PagerInterface');
 
         // Will assert that param fetcher parameters are used for the pager
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())
             ->method('getPager')
             ->with($this->anything(), $this->equalTo($parameters['page']), $this->equalTo($parameters['count']))
@@ -89,20 +90,20 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPostCommentsActionNotFoundExceptionAction()
     {
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
 
         $this->createPostController()->getPostCommentsAction(42, $paramFetcher);
     }
 
     public function testPostPostAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('setContent');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('save')->will($this->returnValue($post));
 
-        $formatterPool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         $formatterPool->expects($this->once())->method('transform')->will($this->returnValue($post->getContent()));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -110,7 +111,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($post));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, null, null, $formFactory, $formatterPool)->postPostAction(new Request());
@@ -120,20 +121,20 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostPostInvalidAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->never())->method('setContent');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->never())->method('save')->will($this->returnValue($post));
 
-        $formatterPool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         $formatterPool->expects($this->never())->method('transform')->will($this->returnValue($post->getContent()));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('bind');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, null, null, $formFactory, $formatterPool)->postPostAction(new Request());
@@ -143,14 +144,14 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('setContent');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
         $postManager->expects($this->once())->method('save')->will($this->returnValue($post));
 
-        $formatterPool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         $formatterPool->expects($this->once())->method('transform')->will($this->returnValue($post->getContent()));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -158,7 +159,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($post));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, null, null, $formFactory, $formatterPool)->putPostAction(1, new Request());
@@ -168,21 +169,21 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostInvalidAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->never())->method('setContent');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
         $postManager->expects($this->never())->method('save')->will($this->returnValue($post));
 
-        $formatterPool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         $formatterPool->expects($this->never())->method('transform')->will($this->returnValue($post->getContent()));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('bind');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, null, null, $formFactory, $formatterPool)->putPostAction(1, new Request());
@@ -192,9 +193,9 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeletePostAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
         $postManager->expects($this->once())->method('delete');
 
@@ -207,7 +208,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue(null));
         $postManager->expects($this->never())->method('delete');
 
@@ -216,18 +217,18 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostPostCommentsAction()
     {
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('isCommentable')->will($this->returnValue(true));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('save');
         $commentManager->expects($this->once())->method('create')->will($this->returnValue($comment));
 
-        $mailer = $this->getMock('Sonata\NewsBundle\Mailer\MailerInterface');
+        $mailer = $this->createMock('Sonata\NewsBundle\Mailer\MailerInterface');
         $mailer->expects($this->once())->method('sendCommentNotification');
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -235,7 +236,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($comment));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $this->assertInstanceOf('FOS\RestBundle\View\View', $this->createPostController($postManager, $commentManager, $mailer, $formFactory)->postPostCommentsAction(1, new Request()));
@@ -243,21 +244,21 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostPostCommentsInvalidFormAction()
     {
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('isCommentable')->will($this->returnValue(true));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('create')->will($this->returnValue($comment));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('bind');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $this->assertInstanceOf('Symfony\Component\Form\Form', $this->createPostController($postManager, $commentManager, null, $formFactory)->postPostCommentsAction(1, new Request()));
@@ -269,10 +270,10 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testPostPostCommentsNotCommentableAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('isCommentable')->will($this->returnValue(false));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
         $this->createPostController($postManager)->postPostCommentsAction(42, new Request());
@@ -280,15 +281,15 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostCommentAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('isCommentable')->will($this->returnValue(true));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
         $commentManager->expects($this->once())->method('save')->will($this->returnValue($comment));
 
@@ -296,7 +297,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('bind');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, $commentManager, null, $formFactory)->putPostCommentsAction(1, 1, new Request());
@@ -306,15 +307,15 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutPostCommentInvalidAction()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->once())->method('isCommentable')->will($this->returnValue(true));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         $postManager->expects($this->once())->method('find')->will($this->returnValue($post));
 
-        $comment = $this->getMock('Sonata\NewsBundle\Model\CommentInterface');
+        $comment = $this->createMock('Sonata\NewsBundle\Model\CommentInterface');
 
-        $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+        $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         $commentManager->expects($this->once())->method('find')->will($this->returnValue($comment));
         $commentManager->expects($this->never())->method('save')->will($this->returnValue($comment));
 
@@ -322,7 +323,7 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('bind');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createPostController($postManager, $commentManager, null, $formFactory)->putPostCommentsAction(1, 1, new Request());
@@ -342,19 +343,19 @@ class PostControllerTest extends \PHPUnit_Framework_TestCase
     protected function createPostController($postManager = null, $commentManager = null, $mailer = null, $formFactory = null, $formatterPool = null)
     {
         if (null === $postManager) {
-            $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+            $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
         }
         if (null === $commentManager) {
-            $commentManager = $this->getMock('Sonata\NewsBundle\Model\CommentManagerInterface');
+            $commentManager = $this->createMock('Sonata\NewsBundle\Model\CommentManagerInterface');
         }
         if (null === $mailer) {
-            $mailer = $this->getMock('Sonata\NewsBundle\Mailer\MailerInterface');
+            $mailer = $this->createMock('Sonata\NewsBundle\Mailer\MailerInterface');
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         }
         if (null === $formatterPool) {
-            $formatterPool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+            $formatterPool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         }
 
         return new PostController($postManager, $commentManager, $mailer, $formFactory, $formatterPool);

--- a/Tests/Document/CommentManagerTest.php
+++ b/Tests/Document/CommentManagerTest.php
@@ -12,16 +12,17 @@
 namespace Sonata\NewsBundle\Tests\Document;
 
 use Sonata\NewsBundle\Document\CommentManager;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Tests the comment manager document.
  */
-class CommentManagerTest extends \PHPUnit_Framework_TestCase
+class CommentManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testImplements()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
 
         $commentManager = new CommentManager('Sonata\NewsBundle\Document\BaseComment', $registry, $postManager);
 

--- a/Tests/Document/PostManagerTest.php
+++ b/Tests/Document/PostManagerTest.php
@@ -12,15 +12,16 @@
 namespace Sonata\NewsBundle\Tests\Document;
 
 use Sonata\NewsBundle\Document\PostManager;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Tests the post manager document.
  */
-class PostManagerTest extends \PHPUnit_Framework_TestCase
+class PostManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testImplements()
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
 
         $postManager = new PostManager('Sonata\NewsBundle\Document\BasePost', $registry);
 

--- a/Tests/Entity/CommentManagerTest.php
+++ b/Tests/Entity/CommentManagerTest.php
@@ -14,13 +14,14 @@ namespace Sonata\NewsBundle\Tests\Entity;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\NewsBundle\Entity\CommentManager;
 use Sonata\NewsBundle\Model\CommentInterface;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Tests the comment manager entity.
  *
  * @author Romain Mouillard <romain.mouillard@gmail.com>
  */
-class CommentManagerTest extends \PHPUnit_Framework_TestCase
+class CommentManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPager()
     {
@@ -80,10 +81,10 @@ class CommentManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        $postManager = $this->getMock('Sonata\NewsBundle\Model\PostManagerInterface');
+        $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
 
         return new CommentManager('Sonata\NewsBundle\Entity\BasePost', $registry, $postManager);
     }

--- a/Tests/Entity/PostManagerTest.php
+++ b/Tests/Entity/PostManagerTest.php
@@ -13,11 +13,12 @@ namespace Sonata\NewsBundle\Tests\Entity;
 
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\NewsBundle\Entity\PostManager;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
 /**
  * Tests the post manager entity.
  */
-class PostManagerTest extends \PHPUnit_Framework_TestCase
+class PostManagerTest extends PHPUnit_Framework_TestCase
 {
     public function assertRelationsEnabled($qb)
     {
@@ -210,7 +211,7 @@ class PostManagerTest extends \PHPUnit_Framework_TestCase
     {
         $em = EntityManagerMockFactory::create($this, $qbCallback, array());
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new PostManager('Sonata\NewsBundle\Entity\BasePost', $registry);

--- a/Tests/Model/BaseModelTest.php
+++ b/Tests/Model/BaseModelTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
+
 class BasePostTest_Post extends \Sonata\NewsBundle\Model\Post
 {
     public function getId()
@@ -19,7 +21,7 @@ class BasePostTest_Post extends \Sonata\NewsBundle\Model\Post
     }
 }
 
-class BasePostTest extends \PHPUnit_Framework_TestCase
+class BasePostTest extends PHPUnit_Framework_TestCase
 {
     public function testIsCommentable()
     {

--- a/Tests/Model/CommentTest.php
+++ b/Tests/Model/CommentTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
+
 class ModelTest_Comment extends \Sonata\NewsBundle\Model\Comment
 {
     public function getId()
@@ -18,7 +20,7 @@ class ModelTest_Comment extends \Sonata\NewsBundle\Model\Comment
     }
 }
 
-class CommentTest extends \PHPUnit_Framework_TestCase
+class CommentTest extends PHPUnit_Framework_TestCase
 {
     public function testSettersGetters()
     {
@@ -29,7 +31,7 @@ class CommentTest extends \PHPUnit_Framework_TestCase
         $comment->setEmail('email@example.org');
         $comment->setMessage('My message');
         $comment->setName('My name');
-        $comment->setPost($this->getMock('Sonata\NewsBundle\Model\PostInterface'));
+        $comment->setPost($this->createMock('Sonata\NewsBundle\Model\PostInterface'));
         $comment->setStatus(1);
         $comment->setUpdatedAt($date);
         $comment->setUrl('http://www.example.org');
@@ -38,7 +40,7 @@ class CommentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($comment->getEmail(), 'email@example.org');
         $this->assertEquals($comment->getMessage(), 'My message');
         $this->assertEquals($comment->getName(), 'My name');
-        $this->assertEquals($comment->getPost(), $this->getMock('Sonata\NewsBundle\Model\PostInterface'));
+        $this->assertEquals($comment->getPost(), $this->createMock('Sonata\NewsBundle\Model\PostInterface'));
         $this->assertEquals($comment->getStatus(), 1);
         $this->assertEquals($comment->getUpdatedAt(), $date);
         $this->assertEquals($comment->getUrl(), 'http://www.example.org');

--- a/Tests/Model/PostTest.php
+++ b/Tests/Model/PostTest.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\NewsBundle\Tests\Model;
 
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
+
 class ModelTest_Post extends \Sonata\NewsBundle\Model\Post
 {
     public function getId()
@@ -21,7 +23,7 @@ class ModelTest_Post extends \Sonata\NewsBundle\Model\Post
 /**
  * Tests the post model.
  */
-class PostTest extends \PHPUnit_Framework_TestCase
+class PostTest extends PHPUnit_Framework_TestCase
 {
     public function testSettersGetters()
     {
@@ -30,7 +32,7 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $post = new ModelTest_Post();
         $post->setAbstract('My abstract content');
         $post->setAuthor('My author');
-        $post->setCollection($this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
+        $post->setCollection($this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
         $post->setCommentsCloseAt($date);
         $post->setCommentsCount(5);
         $post->setCommentsDefaultStatus(1);
@@ -41,14 +43,14 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $post->setEnabled(true);
         $post->setPublicationDateStart($date);
         $post->setRawContent('My raw content');
-        $post->setTags($this->getMock('Sonata\ClassificationBundle\Model\TagInterface'));
+        $post->setTags($this->createMock('Sonata\ClassificationBundle\Model\TagInterface'));
         $post->setTitle('My title');
         $post->setSlug('my-post-slug');
         $post->setUpdatedAt($date);
 
         $this->assertEquals($post->getAbstract(), 'My abstract content');
         $this->assertEquals($post->getAuthor(), 'My author');
-        $this->assertEquals($post->getCollection(), $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
+        $this->assertEquals($post->getCollection(), $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface'));
         $this->assertEquals($post->getCommentsCloseAt(), $date);
         $this->assertEquals($post->getCommentsCount(), 5);
         $this->assertEquals($post->getCommentsDefaultStatus(), 1);
@@ -60,7 +62,7 @@ class PostTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($post->getPublicationDateStart(), $date);
         $this->assertEquals($post->getRawContent(), 'My raw content');
         $this->assertEquals($post->getSlug(), 'my-post-slug');
-        $this->assertEquals($post->getTags(), $this->getMock('Sonata\ClassificationBundle\Model\TagInterface'));
+        $this->assertEquals($post->getTags(), $this->createMock('Sonata\ClassificationBundle\Model\TagInterface'));
         $this->assertEquals($post->getTitle(), 'My title');
         $this->assertEquals($post->getUpdatedAt(), $date);
     }

--- a/Tests/PHPUnit_Framework_TestCase.php
+++ b/Tests/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests;
+
+/**
+ * NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @internal
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
+    }
+}

--- a/Tests/Permalink/CollectionPermalinkTest.php
+++ b/Tests/Permalink/CollectionPermalinkTest.php
@@ -12,15 +12,16 @@
 namespace Sonata\NewsBundle\Tests\Model;
 
 use Sonata\NewsBundle\Permalink\CollectionPermalink;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
-class CollectionPermalinkTest extends \PHPUnit_Framework_TestCase
+class CollectionPermalinkTest extends PHPUnit_Framework_TestCase
 {
     public function testGenerateWithCollection()
     {
-        $collection = $this->getMock('Sonata\ClassificationBundle\Model\CollectionInterface');
+        $collection = $this->createMock('Sonata\ClassificationBundle\Model\CollectionInterface');
         $collection->expects($this->any())->method('getSlug')->will($this->returnValue('the-collection'));
 
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->any())->method('getCollection')->will($this->returnValue($collection));
         $post->expects($this->any())->method('getSlug')->will($this->returnValue('the-slug'));
 
@@ -30,7 +31,7 @@ class CollectionPermalinkTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateWithoutCollection()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->any())->method('getCollection')->will($this->returnValue(null));
         $post->expects($this->any())->method('getSlug')->will($this->returnValue('the-slug'));
 

--- a/Tests/Permalink/DatePermalinkTest.php
+++ b/Tests/Permalink/DatePermalinkTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\NewsBundle\Tests\Model;
 
 use Sonata\NewsBundle\Permalink\DatePermalink;
+use Sonata\NewsBundle\Tests\PHPUnit_Framework_TestCase;
 
-class DatePermalinkTest extends \PHPUnit_Framework_TestCase
+class DatePermalinkTest extends PHPUnit_Framework_TestCase
 {
     public function testGenerate()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->any())->method('getSlug')->will($this->returnValue('the-slug'));
         $post->expects($this->any())->method('getYear')->will($this->returnValue('2011'));
         $post->expects($this->any())->method('getMonth')->will($this->returnValue('12'));
@@ -29,7 +30,7 @@ class DatePermalinkTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomFormatting()
     {
-        $post = $this->getMock('Sonata\NewsBundle\Model\PostInterface');
+        $post = $this->createMock('Sonata\NewsBundle\Model\PostInterface');
         $post->expects($this->any())->method('getSlug')->will($this->returnValue('the-slug'));
         $post->expects($this->any())->method('getYear')->will($this->returnValue('2011'));
         $post->expects($this->any())->method('getMonth')->will($this->returnValue('2'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is for tests only.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

The method `getMock` is deprecated.
