### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Comment.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Comment.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\NewsBundle\Document\Comment" collection="newsComment">
+    <document name="{{ namespace }}\Document\Comment" collection="newsComment">
         <id fieldName="id" id="true" />
 
     </document>

--- a/Resources/config/doctrine/Comment.orm.xml.skeleton
+++ b/Resources/config/doctrine/Comment.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\NewsBundle\Entity\Comment"
+        name="{{ namespace }}\Entity\Comment"
         table="news__comment"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Post.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Post.mongodb.xml.skeleton
@@ -4,8 +4,8 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/orm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\NewsBundle\Document\Post" collection="newsPost"
-          repository-class="Application\Sonata\NewsBundle\Document\PostRepository">
+    <document name="{{ namespace }}\Document\Post" collection="newsPost"
+          repository-class="{{ namespace }}\Document\PostRepository">
 
         <id fieldName="id" id="true" />
 
@@ -22,7 +22,7 @@
 
         <reference-many target-document="Application\Sonata\ClassificationBundle\Document\Tag" field="tags" inversed-by="posts" />
 
-        <reference-many target-document="Application\Sonata\NewsBundle\Document\Comment" field="comments" mapped-by="post">
+        <reference-many target-document="{{ namespace }}\Document\Comment" field="comments" mapped-by="post">
             <cascade>
                 <cascade-persist/>
             </cascade>

--- a/Resources/config/doctrine/Post.orm.xml.skeleton
+++ b/Resources/config/doctrine/Post.orm.xml.skeleton
@@ -9,9 +9,9 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\NewsBundle\Entity\Post"
+        name="{{ namespace }}\Entity\Post"
         table="news__post"
-        repository-class="Application\Sonata\NewsBundle\Entity\PostRepository">
+        repository-class="{{ namespace }}\Entity\PostRepository">
 
         <id name="id" type="integer" column="id">
             <generator strategy="AUTO"/>

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sonata-project/media-bundle": "^3.0",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/formatter-bundle": "^3.0",
-        "sonata-project/easy-extends-bundle": "^2.1",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/intl-bundle": "^2.2.4",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/core-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250