### PR TITLE
added note to setup block bundle first

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -14,7 +14,7 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
 
     composer require nelmio/api-doc-bundle friendsofsymfony/rest-bundle
 
-* Add SonataNewsBundle to your application kernel:
+* Add SonataNewsBundle to your AppKernel:
 
 .. code-block:: php
 
@@ -27,10 +27,11 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
     {
         return array(
             // ...
+
             new Sonata\CoreBundle\SonataCoreBundle(),
-            new Sonata\MarkItUpBundle\SonataMarkItUpBundle(),
             new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
             new Sonata\NewsBundle\SonataNewsBundle(),
+            new Sonata\NewsBundle\SonataBlockBundle(),
             new Sonata\UserBundle\SonataUserBundle(),
             new Sonata\MediaBundle\SonataMediaBundle(),
             new Sonata\AdminBundle\SonataAdminBundle(),
@@ -43,9 +44,14 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
             new Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle(),
             new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
+
+            // ...
         );
     }
 
+.. note::
+
+    `You need to setup SonataBlockBundle first. <https://sonata-project.org/bundles/block/master/doc/reference/installation.html>`_
 
 * Create a configuration file called ``sonata_news.yml``:
 
@@ -209,4 +215,3 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
     news:
         resource: '@SonataNewsBundle/Resources/config/routing/news.xml'
         prefix: /news
-


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a docs change.

Based on #339 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Add a note for setting up BlockBundle first, including a link to the docs
