### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/Admin/CommentAdmin.php
+++ b/Admin/CommentAdmin.php
@@ -15,8 +15,11 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\NewsBundle\Form\Type\CommentStatusType;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CommentAdmin extends AbstractAdmin
 {
@@ -104,7 +107,7 @@ class CommentAdmin extends AbstractAdmin
         if (!$this->isChild()) {
             $formMapper
                 ->with('group_general')
-                    ->add('post', 'sonata_type_model_list')
+                    ->add('post', ModelListType::class)
                 ->end()
             ;
         }
@@ -116,7 +119,7 @@ class CommentAdmin extends AbstractAdmin
                 ->add('url', null, ['required' => false])
             ->end()
             ->with('group_comment')
-                ->add('status', 'sonata_news_comment_status', [
+                ->add('status', CommentStatusType::class, [
                     'expanded' => true,
                     'multiple' => false,
                 ])
@@ -144,7 +147,7 @@ class CommentAdmin extends AbstractAdmin
     {
         $listMapper
             ->addIdentifier('name')
-            ->add('getStatusCode', 'text', ['label' => 'status_code', 'sortable' => 'status'])
+            ->add('getStatusCode', TextType::class, ['label' => 'status_code', 'sortable' => 'status'])
         ;
 
         if (!$this->isChild()) {

--- a/Admin/PostAdmin.php
+++ b/Admin/PostAdmin.php
@@ -17,11 +17,19 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\CoreBundle\Form\Type\DateTimePickerType;
+use Sonata\DoctrineORMAdminBundle\Filter\CallbackFilter;
+use Sonata\FormatterBundle\Form\Type\FormatterType;
 use Sonata\FormatterBundle\Formatter\Pool as FormatterPool;
+use Sonata\NewsBundle\Form\Type\CommentStatusType;
 use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Permalink\PermalinkInterface;
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 class PostAdmin extends AbstractAdmin
 {
@@ -105,10 +113,12 @@ class PostAdmin extends AbstractAdmin
             ->with('group_post', [
                     'class' => 'col-md-8',
                 ])
-                ->add('author', 'sonata_type_model_list')
+                ->add('author', ModelListType::class)
                 ->add('title')
-                ->add('abstract', null, ['attr' => ['rows' => 5]])
-                ->add('content', 'sonata_formatter_type', [
+                ->add('abstract', TextareaType::class, [
+                    'attr' => ['rows' => 5],
+                ])
+                ->add('content', FormatterType::class, [
                     'event_dispatcher' => $formMapper->getFormBuilder()->getEventDispatcher(),
                     'format_field' => 'contentFormatter',
                     'source_field' => 'rawContent',
@@ -124,32 +134,40 @@ class PostAdmin extends AbstractAdmin
             ->with('group_status', [
                     'class' => 'col-md-4',
                 ])
-                ->add('enabled', null, ['required' => false])
-                ->add('image', 'sonata_type_model_list', ['required' => false], [
+                ->add('enabled', CheckboxType::class, ['required' => false])
+                ->add('image', ModelListType::class, ['required' => false], [
                     'link_parameters' => [
                         'context' => 'news',
                         'hide_context' => true,
                     ],
                 ])
 
-                ->add('publicationDateStart', 'sonata_type_datetime_picker', ['dp_side_by_side' => true])
-                ->add('commentsCloseAt', 'sonata_type_datetime_picker', [
+                ->add('publicationDateStart', DateTimePickerType::class, [
+                    'dp_side_by_side' => true,
+                ])
+                ->add('commentsCloseAt', DateTimePickerType::class, [
                     'dp_side_by_side' => true,
                     'required' => false,
                 ])
-                ->add('commentsEnabled', null, ['required' => false])
-                ->add('commentsDefaultStatus', 'sonata_news_comment_status', ['expanded' => true])
+                ->add('commentsEnabled', CheckboxType::class, [
+                    'required' => false,
+                ])
+                ->add('commentsDefaultStatus', CommentStatusType::class, [
+                    'expanded' => true,
+                ])
             ->end()
 
             ->with('group_classification', [
                 'class' => 'col-md-4',
                 ])
-                ->add('tags', 'sonata_type_model_autocomplete', [
+                ->add('tags', ModelAutocompleteType::class, [
                     'property' => 'name',
                     'multiple' => 'true',
                     'required' => false,
                 ])
-                ->add('collection', 'sonata_type_model_list', ['required' => false])
+                ->add('collection', ModelListType::class, [
+                    'required' => false,
+                ])
             ->end()
         ;
     }
@@ -182,7 +200,7 @@ class PostAdmin extends AbstractAdmin
             ->add('enabled')
             ->add('tags', null, ['field_options' => ['expanded' => true, 'multiple' => true]])
             ->add('author')
-            ->add('with_open_comments', 'doctrine_orm_callback', [
+            ->add('with_open_comments', CallbackFilter::class, [
 //                'callback'   => array($this, 'getWithOpenCommentFilter'),
                 'callback' => function ($queryBuilder, $alias, $field, $data) use ($that) {
                     if (!is_array($data) || !$data['value']) {

--- a/Block/RecentCommentsBlockService.php
+++ b/Block/RecentCommentsBlockService.php
@@ -16,10 +16,14 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -90,17 +94,17 @@ class RecentCommentsBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number', 'integer', [
+                ['number', IntegerType::class, [
                     'required' => true,
                     'label' => 'form.label_number',
                 ]],
-                ['title', 'text', [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['mode', 'choice', [
+                ['mode', ChoiceType::class, [
                     'choices' => [
                         'public' => 'form.label_mode_public',
                         'admin' => 'form.label_mode_admin',

--- a/Block/RecentPostsBlockService.php
+++ b/Block/RecentPostsBlockService.php
@@ -16,10 +16,14 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -90,17 +94,17 @@ class RecentPostsBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['number', 'integer', [
+                ['number', IntegerType::class, [
                     'required' => true,
                     'label' => 'form.label_number',
                 ]],
-                ['title', 'text', [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['mode', 'choice', [
+                ['mode', ChoiceType::class, [
                     'choices' => [
                         'public' => 'form.label_mode_public',
                         'admin' => 'form.label_mode_admin',

--- a/Form/Type/CommentType.php
+++ b/Form/Type/CommentType.php
@@ -12,6 +12,10 @@
 namespace Sonata\NewsBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -23,10 +27,20 @@ class CommentType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', null, ['label' => 'form.comment.name'])
-            ->add('email', 'email', ['required' => false, 'label' => 'form.comment.email'])
-            ->add('url', 'url', ['required' => false, 'label' => 'form.comment.url'])
-            ->add('message', null, ['label' => 'form.comment.message'])
+            ->add('name', TextType::class, [
+                'label' => 'form.comment.name',
+            ])
+            ->add('email', EmailType::class, [
+                'required' => false,
+                'label' => 'form.comment.email',
+            ])
+            ->add('url', UrlType::class, [
+                'required' => false,
+                'label' => 'form.comment.url',
+            ])
+            ->add('message', TextareaType::class, [
+                'label' => 'form.comment.message',
+            ])
         ;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
-        "symfony/console": "^2.3",
-        "symfony/form": "^2.3",
-        "symfony/framework-bundle": "^2.3",
-        "symfony/templating": "^2.3",
+        "php": "^7.1",
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/templating": "^2.8 || ^3.2",
         "sonata-project/admin-bundle": "^3.4",
         "sonata-project/user-bundle": "^3.0",
         "sonata-project/media-bundle": "^3.0",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Removed usage of old form type aliases

### Removed
- support for old versions of php and Symfony
```
