### PR TITLE
fixed mongoDb metadata config for Post Document #371

### DIFF
--- a/Resources/config/doctrine/BasePost.mongodb.xml
+++ b/Resources/config/doctrine/BasePost.mongodb.xml
@@ -12,7 +12,7 @@
         <field name="commentsEnabled" type="boolean" fieldName="commentsEnabled"/>
         <field name="commentsCloseAt" type="timestamp" fieldName="commentsCloseAt"/>
         <field name="commentsDefaultStatus" type="int" fieldName="commentsDefaultStatus"/>
-        <field name="commentsCount" type="int" fieldName="comments_count" default="0"/>
+        <field name="commentsCount" type="int" fieldName="commentsCount" default="0"/>
         <field name="createdAt" type="timestamp" fieldName="createdAt"/>
         <field name="updatedAt" type="timestamp" fieldName="updatedAt"/>
         <lifecycle-callbacks>

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,8 @@
 UPGRADE 3.x
 ===========
 
+- Doctrine MongoDb metadata `comments_count` has been changed to `commentsCount`. In case of having problems, please update your collections.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
I am targeting this branch, because this does not work on this branch regarding to dependencies. NOT: This is a BC break but this needs to be fixed.

Closes #371 

## Changelog
```markdown
### Fixed
- Fixed `Post` Document mongoDb metadata from `comments_count` to `commentsCount`
```

## To do
- [x] Add an upgrade note

## Subject

Can you please let me know how to update Docs or add Notes?
