### PR TITLE
Removed deprecated form alias usage

### DIFF
--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\NewsBundle\Controller;
 
+use Sonata\NewsBundle\Form\Type\CommentType;
 use Sonata\NewsBundle\Model\BlogInterface;
 use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
@@ -257,7 +258,7 @@ class PostController extends Controller
         $comment->setPost($post);
         $comment->setStatus($post->getCommentsDefaultStatus());
 
-        return $this->get('form.factory')->createNamed('comment', 'sonata_post_comment', $comment, [
+        return $this->get('form.factory')->createNamed('comment', CommentType::class, $comment, [
             'action' => $this->generateUrl('sonata_news_add_comment', [
                 'id' => $post->getId(),
             ]),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed deprecated form alias usage
```

## Subject

This won't work in symfony 4.x.
