### PR TITLE
add missing menuRegistry argument to breadcrumb service

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,10 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated
+Initializing `Sonata\NewsBundle\Block\Breadcrumb\NewsPostBreadcrumbBlockService` class without the `menuRegistry` parameter is deprecated, Use `Sonata\BlockBundle\Menu\MenuRegistryInterface` as last argument.
+
+### Changed
 - Doctrine MongoDb metadata `comments_count` has been changed to `commentsCount`. In case of having problems, please update your collections.
 
 UPGRADE FROM 3.0 to 3.1

--- a/src/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
@@ -14,6 +14,7 @@ namespace Sonata\NewsBundle\Block\Breadcrumb;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Menu\MenuRegistryInterface;
 use Sonata\NewsBundle\Model\BlogInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -31,18 +32,38 @@ class NewsPostBreadcrumbBlockService extends BaseNewsBreadcrumbBlockService
     protected $blog;
 
     /**
-     * @param string                $context
-     * @param string                $name
-     * @param EngineInterface       $templating
-     * @param MenuProviderInterface $menuProvider
-     * @param FactoryInterface      $factory
-     * @param BlogInterface         $blog
+     * @param string                      $context
+     * @param string                      $name
+     * @param EngineInterface             $templating
+     * @param MenuProviderInterface       $menuProvider
+     * @param FactoryInterface            $factory
+     * @param BlogInterface               $blog
+     * @param MenuRegistryInterface|array $menuRegistry
+     *
+     * NEXT_MAJOR: Use MenuRegistryInterface as a type of $menuRegistry argument
      */
-    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, BlogInterface $blog)
+    public function __construct($context, $name, EngineInterface $templating, MenuProviderInterface $menuProvider, FactoryInterface $factory, BlogInterface $blog, $menuRegistry = [])
     {
         $this->blog = $blog;
 
-        parent::__construct($context, $name, $templating, $menuProvider, $factory);
+        /*
+         * NEXT_MAJOR: Remove if statements
+         */
+        if (!$menuRegistry instanceof MenuRegistryInterface && !is_array($menuRegistry)) {
+            throw new \InvalidArgumentException(sprintf(
+                'MenuRegistry must be either type of array or instance of %s',
+                MenuRegistryInterface::class
+            ));
+        } elseif (is_array($menuRegistry)) {
+            @trigger_error(sprintf(
+                'Initializing %s without menuRegistry parameter is deprecated since 2.x and will'.
+                ' be removed in 3.0. Use an instance of %s as last argument.',
+                __CLASS__,
+                MenuRegistryInterface::class
+            ), E_USER_DEPRECATED);
+        }
+
+        parent::__construct($context, $name, $templating, $menuProvider, $factory, $menuRegistry);
     }
 
     /**

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.news.block.breadcrumb_post" class="Sonata\NewsBundle\Block\Breadcrumb\NewsPostBreadcrumbBlockService">
             <tag name="sonata.block"/>
@@ -33,6 +34,7 @@
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is a BC.

See: https://github.com/sonata-project/SonataSeoBundle/pull/241

## Changelog

```markdown
### Changed
- do not use deprecated array for block menu service
```

## To do

- [x] Add an upgrade note
