### PR TITLE
Fixed calling deprecated twig tag

### DIFF
--- a/src/Resources/views/Post/view.html.twig
+++ b/src/Resources/views/Post/view.html.twig
@@ -57,13 +57,13 @@
         {{ post.content|raw }}
     </div>
 
-    {% render(controller('SonataNewsBundle:Post:comments', {'postId': post.id})) %}
+    {{ render(controller('SonataNewsBundle:Post:comments', {'postId': post.id})) }}
 
     {% if post.iscommentable %}
-        {% render(controller('SonataNewsBundle:Post:addCommentForm', {
+        {{ render(controller('SonataNewsBundle:Post:addCommentForm', {
             'postId': post.id,
             'form': form
-        })) %}
+        })) }}
     {% else %}
         <div>
             {{ 'message_comments_are_closed'|trans({}, 'SonataNewsBundle') }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed calling deprecated twig tag
```
## Subject

When using twig 2.0, an error is thrown:

```
  [Twig_Error_Syntax]    
  Unknown "render" tag.  
```
