### PR TITLE
Allow sonata user bundle 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "^2.8 || ^3.2",
         "symfony/templating": "^2.8 || ^3.2",
         "sonata-project/admin-bundle": "^3.4",
-        "sonata-project/user-bundle": "^3.0",
+        "sonata-project/user-bundle": "^3.0 || ^4.0",
         "sonata-project/media-bundle": "^3.0",
         "sonata-project/classification-bundle": "^3.0",
         "sonata-project/formatter-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support fos `sonata-project/user-bundle` 4
```
