### PR TITLE
Added missing translation to CommentStatusType

### DIFF
--- a/src/Form/Type/CommentStatusType.php
+++ b/src/Form/Type/CommentStatusType.php
@@ -12,7 +12,19 @@
 namespace Sonata\NewsBundle\Form\Type;
 
 use Sonata\CoreBundle\Form\Type\BaseStatusType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CommentStatusType extends BaseStatusType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'choice_translation_domain' => 'SonataNewsBundle',
+        ]);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Added missing translation to `CommentStatusType`
```
