### PR TITLE
Restore PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "sonata-project/admin-bundle": "^3.28",
         "sonata-project/classification-bundle": "^3.5",
         "sonata-project/core-bundle": "^3.7.1",

--- a/src/Form/Type/CommentStatusType.php
+++ b/src/Form/Type/CommentStatusType.php
@@ -21,7 +21,7 @@ class CommentStatusType extends BaseStatusType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 


### PR DESCRIPTION
After the back and forth of PHP versions, we lost 7.1 on master, which was not intended. This PR restores it.