### PR TITLE
Don't call the translator in breadcrumbs

### DIFF
--- a/src/Block/Breadcrumb/NewsArchiveBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/NewsArchiveBreadcrumbBlockService.php
@@ -55,6 +55,9 @@ class NewsArchiveBreadcrumbBlockService extends BaseNewsBreadcrumbBlockService
                 'routeParameters' => [
                     'collection' => $collection->getSlug(),
                 ],
+                'extras' => [
+                    'translation_domain' => false,
+                ],
             ]);
         }
 
@@ -63,6 +66,9 @@ class NewsArchiveBreadcrumbBlockService extends BaseNewsBreadcrumbBlockService
                 'route' => 'sonata_news_tag',
                 'routeParameters' => [
                     'tag' => $tag->getSlug(),
+                ],
+                'extras' => [
+                    'translation_domain' => false,
                 ],
             ]);
         }

--- a/src/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/NewsPostBreadcrumbBlockService.php
@@ -78,6 +78,9 @@ class NewsPostBreadcrumbBlockService extends BaseNewsBreadcrumbBlockService
                 'routeParameters' => [
                     'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
                 ],
+                'extras' => [
+                    'translation_domain' => false,
+                ],
             ]);
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Don't call the translator in breadcrumbs
```

## Subject

We don't need to call the translator on user generated content.
