### PR TITLE
Fixed creating new swift message

### DIFF
--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -96,7 +96,7 @@ class Mailer implements MailerInterface
         // Render the email, use the first line as the subject, and the rest as the body
         list($subject, $body) = explode("\n", trim($renderedTemplate), 2);
 
-        $message = \Swift_Message::newInstance()
+        $message = $this->mailer->createMessage()
             ->setSubject($subject)
             ->setFrom($fromEmail)
             ->setTo($toEmail)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix for #426 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
 - Fixed creating new swift message
```


## Subject

According to https://github.com/swiftmailer/swiftmailer/blob/5f617743a4bf70c2f453efdbc850abe04de6f1af/CHANGES#L30, the method was removed.
