### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "conflict": {
         "jms/serializer": "<0.13",
-        "sonata-project/block-bundle": "<3.2",
+        "sonata-project/block-bundle": "<3.11",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
         "sonata-project/seo-bundle": "<2.0 || >=3.0"
@@ -50,7 +50,7 @@
         "friendsofsymfony/rest-bundle": "^1.1",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
-        "sonata-project/block-bundle": "^3.8",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/doctrine-orm-admin-bundle": "^3.2",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.4"

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -22,7 +22,7 @@ Advanced Configuration
             notification:
                 emails:   [email@example.org, email2@example.org]
                 from:     no-reply@sonata-project.org
-                template: 'SonataNewsBundle:Mail:comment_notification.txt.twig'
+                template: '@SonataNews/Mail/comment_notification.txt.twig'
 
         class:
             post:       Application\Sonata\NewsBundle\Entity\Post

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -70,7 +70,7 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
             notification:
                 emails:   [email@example.org, email2@example.org]
                 from:     no-reply@sonata-project.org
-                template: 'SonataNewsBundle:Mail:comment_notification.txt.twig'
+                template: '@SonataNews/Mail/comment_notification.txt.twig'
 
     doctrine:
         orm:

--- a/src/Admin/PostAdmin.php
+++ b/src/Admin/PostAdmin.php
@@ -179,7 +179,7 @@ class PostAdmin extends AbstractAdmin
     {
         $listMapper
             ->add('custom', 'string', [
-                'template' => 'SonataNewsBundle:Admin:list_post_custom.html.twig',
+                'template' => '@SonataNews/Admin/list_post_custom.html.twig',
                 'label' => 'Post',
                 'sortable' => 'title',
             ])

--- a/src/Block/RecentCommentsBlockService.php
+++ b/src/Block/RecentCommentsBlockService.php
@@ -125,7 +125,7 @@ class RecentCommentsBlockService extends AbstractAdminBlockService
             'number' => 5,
             'mode' => 'public',
             'title' => 'Recent Comments',
-            'template' => 'SonataNewsBundle:Block:recent_comments.html.twig',
+            'template' => '@SonataNews/Block/recent_comments.html.twig',
         ]);
     }
 

--- a/src/Block/RecentPostsBlockService.php
+++ b/src/Block/RecentPostsBlockService.php
@@ -125,7 +125,7 @@ class RecentPostsBlockService extends AbstractAdminBlockService
             'number' => 5,
             'mode' => 'public',
             'title' => 'Recent Posts',
-            'template' => 'SonataNewsBundle:Block:recent_posts.html.twig',
+            'template' => '@SonataNews/Block/recent_posts.html.twig',
         ]);
     }
 

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -62,7 +62,7 @@ class PostController extends Controller
             'route_parameters' => $request->get('_route_params'),
         ], $parameters);
 
-        $response = $this->render(sprintf('SonataNewsBundle:Post:archive.%s.twig', $request->getRequestFormat()), $parameters);
+        $response = $this->render(sprintf('@SonataNews/Post/archive.%s.twig', $request->getRequestFormat()), $parameters);
 
         if ('rss' === $request->getRequestFormat()) {
             $response->headers->set('Content-Type', 'application/rss+xml');
@@ -188,7 +188,7 @@ class PostController extends Controller
             ;
         }
 
-        return $this->render('SonataNewsBundle:Post:view.html.twig', [
+        return $this->render('@SonataNews/Post/view.html.twig', [
             'post' => $post,
             'form' => false,
             'blog' => $this->getBlog(),
@@ -220,7 +220,7 @@ class PostController extends Controller
                 'status' => CommentInterface::STATUS_VALID,
             ], 1, 500); //no limit
 
-        return $this->render('SonataNewsBundle:Post:comments.html.twig', [
+        return $this->render('@SonataNews/Post/comments.html.twig', [
             'pager' => $pager,
         ]);
     }
@@ -241,7 +241,7 @@ class PostController extends Controller
             $form = $this->getCommentForm($post);
         }
 
-        return $this->render('SonataNewsBundle:Post:comment_form.html.twig', [
+        return $this->render('@SonataNews/Post/comment_form.html.twig', [
             'form' => $form->createView(),
             'post_id' => $postId,
         ]);
@@ -308,7 +308,7 @@ class PostController extends Controller
             ]));
         }
 
-        return $this->render('SonataNewsBundle:Post:view.html.twig', [
+        return $this->render('@SonataNews/Post/view.html.twig', [
             'post' => $post,
             'form' => $form,
         ]);

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -35,8 +35,8 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="inner_list_row">SonataNewsBundle:Admin:inner_row_comment.html.twig</argument>
-                    <argument key="base_list_field">SonataAdminBundle:CRUD:base_list_flat_field.html.twig</argument>
+                    <argument key="inner_list_row">@SonataNews/Admin/inner_row_comment.html.twig</argument>
+                    <argument key="base_list_field">@SonataAdmin/CRUD/base_list_flat_field.html.twig</argument>
                 </argument>
             </call>
         </service>

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -4,14 +4,14 @@
         <service id="sonata.news.block.recent_posts" class="Sonata\NewsBundle\Block\RecentPostsBlockService">
             <tag name="sonata.block"/>
             <argument>sonata.news.block.recent_posts</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.news.manager.post"/>
             <argument type="service" id="sonata.admin.pool" on-invalid="ignore"/>
         </service>
         <service id="sonata.news.block.recent_comments" class="Sonata\NewsBundle\Block\RecentCommentsBlockService">
             <tag name="sonata.block"/>
             <argument>sonata.news.block.recent_comments</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.news.manager.comment"/>
             <argument type="service" id="sonata.admin.pool" on-invalid="ignore"/>
         </service>
@@ -20,7 +20,7 @@
             <tag name="sonata.breadcrumb"/>
             <argument>news_archive</argument>
             <argument>sonata.news.block.breadcrumb_archive</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>
@@ -29,7 +29,7 @@
             <tag name="sonata.breadcrumb"/>
             <argument>news_post</argument>
             <argument>sonata.news.block.breadcrumb_post</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
             <argument type="service" id="sonata.news.blog"/>

--- a/src/Resources/config/core.xml
+++ b/src/Resources/config/core.xml
@@ -15,7 +15,7 @@
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.hash.generator"/>
             <argument type="service" id="router"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument/>
         </service>
     </services>

--- a/src/Resources/views/Admin/inner_row_comment.html.twig
+++ b/src/Resources/views/Admin/inner_row_comment.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_flat_inner_row.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_flat_inner_row.html.twig' %}
 
 {% block row %}
 

--- a/src/Resources/views/Admin/list_post_custom.html.twig
+++ b/src/Resources/views/Admin/list_post_custom.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     <div class="col-sm-2 centered">


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details