### PR TITLE
Added more options to blocks

### DIFF
--- a/src/Block/RecentCommentsBlockService.php
+++ b/src/Block/RecentCommentsBlockService.php
@@ -101,8 +101,20 @@ class RecentCommentsBlockService extends AbstractAdminBlockService
                     'label' => 'form.label_number',
                 ]],
                 ['title', TextType::class, [
-                    'required' => false,
                     'label' => 'form.label_title',
+                    'required' => false,
+                ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
+                ]],
+                ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
+                ['class', TextType::class, [
+                    'label' => 'form.label_class',
+                    'required' => false,
                 ]],
                 ['mode', ChoiceType::class, [
                     'choices' => [
@@ -124,7 +136,10 @@ class RecentCommentsBlockService extends AbstractAdminBlockService
         $resolver->setDefaults([
             'number' => 5,
             'mode' => 'public',
-            'title' => 'Recent Comments',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-comments',
+            'class' => null,
             'template' => '@SonataNews/Block/recent_comments.html.twig',
         ]);
     }

--- a/src/Block/RecentPostsBlockService.php
+++ b/src/Block/RecentPostsBlockService.php
@@ -101,8 +101,20 @@ class RecentPostsBlockService extends AbstractAdminBlockService
                     'label' => 'form.label_number',
                 ]],
                 ['title', TextType::class, [
-                    'required' => false,
                     'label' => 'form.label_title',
+                    'required' => false,
+                ]],
+                ['translation_domain', TextType::class, [
+                    'label' => 'form.label_translation_domain',
+                    'required' => false,
+                ]],
+                ['icon', TextType::class, [
+                    'label' => 'form.label_icon',
+                    'required' => false,
+                ]],
+                ['class', TextType::class, [
+                    'label' => 'form.label_class',
+                    'required' => false,
                 ]],
                 ['mode', ChoiceType::class, [
                     'choices' => [
@@ -124,7 +136,10 @@ class RecentPostsBlockService extends AbstractAdminBlockService
         $resolver->setDefaults([
             'number' => 5,
             'mode' => 'public',
-            'title' => 'Recent Posts',
+            'title' => null,
+            'translation_domain' => null,
+            'icon' => 'fa fa-pencil',
+            'class' => null,
             'template' => '@SonataNews/Block/recent_posts.html.twig',
         ]);
     }

--- a/src/Resources/translations/SonataNewsBundle.de.xliff
+++ b/src/Resources/translations/SonataNewsBundle.de.xliff
@@ -475,6 +475,18 @@
                 <source>moderate</source>
                 <target>Moderiert</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Übersetzungsdatei</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Klasse</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataNewsBundle.en.xliff
+++ b/src/Resources/translations/SonataNewsBundle.en.xliff
@@ -467,6 +467,18 @@ Quick moderation links :
                 <source>moderate</source>
                 <target>moderate</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Translation domain</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icon</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>CSS Class</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataNewsBundle.fr.xliff
+++ b/src/Resources/translations/SonataNewsBundle.fr.xliff
@@ -467,6 +467,18 @@ Liens de modération rapide :
                 <source>moderate</source>
                 <target>moderate</target>
             </trans-unit>
+            <trans-unit id="form.label_translation_domain">
+                <source>form.label_translation_domain</source>
+                <target>Domaine de traduction</target>
+            </trans-unit>
+            <trans-unit id="form.label_icon">
+                <source>form.label_icon</source>
+                <target>Icône</target>
+            </trans-unit>
+            <trans-unit id="form.label_class">
+                <source>form.label_class</source>
+                <target>Classe CSS</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Block/recent_comments.html.twig
+++ b/src/Resources/views/Block/recent_comments.html.twig
@@ -33,7 +33,9 @@ file that was distributed with this source code.
             <div class="list-group">
                 {% for comment in pager.getResults() %}
                     {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
-                        <a class="list-group-item" href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('edit', { 'id': comment.id }) }}">
+                        <a class="list-group-item"
+                           href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('edit', { 'id': comment.id }) }}"
+                        >
                             <span class="label label-{{ comment|sonata_status_class }}">
                                 {% if comment.status == constant('Sonata\\NewsBundle\\Model\\CommentInterface::STATUS_INVALID') %}
                                     {{ 'label_comment_invalid'|trans({}, 'SonataNewsBundle') }}
@@ -49,7 +51,10 @@ file that was distributed with this source code.
                             {{ comment.name }} - {{ comment.message|truncate(30) }}
                         </a>
                     {% else %}
-                        <a class="list-group-item" href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(comment.post) }) }}">{{ comment.name }} - {{ comment.message|truncate(30) }}
+                        <a class="list-group-item"
+                           href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(comment.post) }) }}"
+                        >
+                            {{ comment.name }} - {{ comment.message|truncate(30) }}
                         </a>
                     {% endif %}
                 {% else %}

--- a/src/Resources/views/Block/recent_comments.html.twig
+++ b/src/Resources/views/Block/recent_comments.html.twig
@@ -12,16 +12,16 @@ file that was distributed with this source code.
 
 {% block block %}
 
-    <div class="sonata-news-block-recent-comment box box-primary">
+    <div class="panel panel-default">
         {% if settings.title %}
-            <div class="box-header with-border">
-                <h3 class="box-title">
+            <div class="panel-heading">
+                <h3 class="panel-title">
                     <i class="fa fa-comments fa-fw"></i> {{ settings.title }}
                 </h3>
             </div>
         {% endif %}
 
-        <div class="box-body">
+        <div class="panel-body">
             {% sonata_template_box 'This is the recent posts comments block.' %}
 
             <div class="sonata-blog-post-container list-group">
@@ -52,7 +52,7 @@ file that was distributed with this source code.
             </div>
         </div>
 
-        <div class="box-footer">
+        <div class="panel-footer">
             {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
                 <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_comments'|trans({}, 'SonataNewsBundle') }}</a>
             {% endif %}

--- a/src/Resources/views/Block/recent_comments.html.twig
+++ b/src/Resources/views/Block/recent_comments.html.twig
@@ -11,20 +11,26 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-
-    <div class="panel panel-default">
-        {% if settings.title %}
+    <div class="panel panel-default {{ settings.class }}">
+        {% if settings.title is not empty %}
             <div class="panel-heading">
-                <h3 class="panel-title">
-                    <i class="fa fa-comments fa-fw"></i> {{ settings.title }}
-                </h3>
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
             </div>
         {% endif %}
 
         <div class="panel-body">
             {% sonata_template_box 'This is the recent posts comments block.' %}
 
-            <div class="sonata-blog-post-container list-group">
+            <div class="list-group">
                 {% for comment in pager.getResults() %}
                     {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
                         <a class="list-group-item" href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('edit', { 'id': comment.id }) }}">
@@ -54,7 +60,12 @@ file that was distributed with this source code.
 
         <div class="panel-footer">
             {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
-                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_comments'|trans({}, 'SonataNewsBundle') }}</a>
+                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.comment').generateUrl('list') }}"
+                   class="btn btn-primary btn-block"
+                >
+                    <i class="fa fa-list"></i>
+                    {{ 'view_all_comments'|trans({}, 'SonataNewsBundle') }}
+                </a>
             {% endif %}
         </div>
     </div>

--- a/src/Resources/views/Block/recent_posts.html.twig
+++ b/src/Resources/views/Block/recent_posts.html.twig
@@ -11,18 +11,26 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">
-                <i class="fa fa-pencil"></i> {{ settings.title }}
-            </h3>
-        </div>
+    <div class="panel panel-default {{ settings.class }}">
+        {% if settings.title is not empty %}
+            <div class="panel-heading">
+                <h4 class="panel-title">
+                    {% if settings.icon %}
+                        <i class="{{ settings.icon }}" aria-hidden="true"></i>
+                    {% endif %}
+                    {% if settings.translation_domain %}
+                        {{ settings.title|trans({}, settings.translation_domain) }}
+                    {% else %}
+                        {{ settings.title }}
+                    {% endif %}
+                </h4>
+            </div>
+        {% endif %}
 
         <div class="panel-body">
             {% sonata_template_box 'This is the recent posts block.' %}
 
-            <div class="sonata-blog-post-container list-group">
+            <div class="list-group">
                 {% for post in pager.getResults() %}
                     {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
                         <a class="list-group-item" href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('edit', { 'id': post.id }) }}">
@@ -32,7 +40,8 @@ file that was distributed with this source code.
                             <span class="label">{{ 'post_is_not_public'|trans({}, 'SonataNewsBundle') }}</span>
                             {% endif %}&nbsp;
 
-                            {{ post.title }} - {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} - {{ post.publicationDateStart | format_date }}</a>
+                            {{ post.title }} - {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} - {{ post.publicationDateStart | format_date }}
+                        </a>
                     {% else %}
                         <a class="list-group-item" href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(post) }) }}">{{ post.title }}</a> - {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} - {{ post.publicationDateStart | format_date }}
                     {% endif %}
@@ -44,11 +53,12 @@ file that was distributed with this source code.
 
         <div class="panel-footer">
             {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
-                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}</a>
+                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
+                </a>
             {% else %}
-                <a href="{{ url('sonata_news_archive') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}</a>
+                <a href="{{ url('sonata_news_archive') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
+                </a>
             {% endif %}
         </div>
     </div>
-
 {% endblock %}

--- a/src/Resources/views/Block/recent_posts.html.twig
+++ b/src/Resources/views/Block/recent_posts.html.twig
@@ -33,17 +33,26 @@ file that was distributed with this source code.
             <div class="list-group">
                 {% for post in pager.getResults() %}
                     {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
-                        <a class="list-group-item" href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('edit', { 'id': post.id }) }}">
-                            {% if post.ispublic %}
+                        <a class="list-group-item"
+                           href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('edit', { 'id': post.id }) }}"
+                        >
+
+                        {% if post.ispublic %}
                             <span class="label label-success">{{ 'post_is_public'|trans({}, 'SonataNewsBundle') }}</span>
                         {% else %}
                             <span class="label">{{ 'post_is_not_public'|trans({}, 'SonataNewsBundle') }}</span>
-                            {% endif %}&nbsp;
+                        {% endif %}&nbsp;
 
-                            {{ post.title }} - {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} - {{ post.publicationDateStart | format_date }}
+                        {{ post.title }} -
+                        {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} -
+                        {{ post.publicationDateStart | format_date }}
                         </a>
                     {% else %}
-                        <a class="list-group-item" href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(post) }) }}">{{ post.title }}</a> - {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} - {{ post.publicationDateStart | format_date }}
+                        <a class="list-group-item" href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(post) }) }}">
+                            {{ post.title }}
+                        </a> -
+                        {{ 'archive_author'|trans({'%author%': post.author }, 'SonataNewsBundle') }} -
+                        {{ post.publicationDateStart | format_date }}
                     {% endif %}
                 {% else %}
                     <a class="list-group-item" href="#">{{ 'no_post_found'|trans({}, 'SonataNewsBundle') }}</a>
@@ -53,10 +62,15 @@ file that was distributed with this source code.
 
         <div class="panel-footer">
             {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
-                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
+                <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('list') }}"
+                   class="btn btn-primary btn-block"
+                >
+                    <i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
                 </a>
             {% else %}
-                <a href="{{ url('sonata_news_archive') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
+                <a href="{{ url('sonata_news_archive') }}" class="btn btn-primary btn-block">
+                    <i class="fa fa-list"></i>
+                    {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}
                 </a>
             {% endif %}
         </div>

--- a/src/Resources/views/Block/recent_posts.html.twig
+++ b/src/Resources/views/Block/recent_posts.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                            href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('edit', { 'id': post.id }) }}"
                         >
 
-                        {% if post.ispublic %}
+                        {% if post.isPublic %}
                             <span class="label label-success">{{ 'post_is_public'|trans({}, 'SonataNewsBundle') }}</span>
                         {% else %}
                             <span class="label">{{ 'post_is_not_public'|trans({}, 'SonataNewsBundle') }}</span>

--- a/src/Resources/views/Block/recent_posts.html.twig
+++ b/src/Resources/views/Block/recent_posts.html.twig
@@ -12,14 +12,14 @@ file that was distributed with this source code.
 
 {% block block %}
 
-    <div class="sonata-news-block-recent-post box box-primary">
-        <div class="box-header with-border">
-            <h3 class="box-title">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
                 <i class="fa fa-pencil"></i> {{ settings.title }}
             </h3>
         </div>
 
-        <div class="box-body">
+        <div class="panel-body">
             {% sonata_template_box 'This is the recent posts block.' %}
 
             <div class="sonata-blog-post-container list-group">
@@ -42,7 +42,7 @@ file that was distributed with this source code.
             </div>
         </div>
 
-        <div class="box-footer">
+        <div class="panel-footer">
             {% if context.getSetting('mode') == 'admin' and admin_pool is defined %}
                 <a href="{{ admin_pool.getAdminByAdminCode('sonata.news.admin.post').generateUrl('list') }}" class="btn btn-primary btn-block"><i class="fa fa-list"></i> {{ 'view_all_posts'|trans({}, 'SonataNewsBundle') }}</a>
             {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC (if you ignore the html changes).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
 - added block title translation domain option
 - added block icon option
 - added block class option

### Changed
 - replaced box with bootstrap panel layout in blocks

### Removed
 - Removed default title from blocks
```

