### PR TITLE
Fixed wrong translation key

### DIFF
--- a/src/Admin/PostAdmin.php
+++ b/src/Admin/PostAdmin.php
@@ -180,7 +180,7 @@ class PostAdmin extends AbstractAdmin
         $listMapper
             ->add('custom', 'string', [
                 'template' => '@SonataNews/Admin/list_post_custom.html.twig',
-                'label' => 'Post',
+                'label' => 'list.label_post',
                 'sortable' => 'title',
             ])
             ->add('commentsEnabled', null, ['editable' => true])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong translation key
```

## Subject

The translator was using a label instead of an translation key:

<img width="1039" alt="bildschirmfoto 2018-02-05 um 17 16 28" src="https://user-images.githubusercontent.com/3440437/35815302-6f81ea42-0a98-11e8-9b95-c50e63630a87.PNG">

