### PR TITLE
Fixed wrong translation in blocks

### DIFF
--- a/src/Block/RecentCommentsBlockService.php
+++ b/src/Block/RecentCommentsBlockService.php
@@ -118,8 +118,8 @@ class RecentCommentsBlockService extends AbstractAdminBlockService
                 ]],
                 ['mode', ChoiceType::class, [
                     'choices' => [
-                        'public' => 'form.label_mode_public',
-                        'admin' => 'form.label_mode_admin',
+                        'form.label_mode_public' => 'public',
+                        'form.label_mode_admin' => 'admin',
                     ],
                     'label' => 'form.label_mode',
                 ]],

--- a/src/Block/RecentPostsBlockService.php
+++ b/src/Block/RecentPostsBlockService.php
@@ -118,8 +118,8 @@ class RecentPostsBlockService extends AbstractAdminBlockService
                 ]],
                 ['mode', ChoiceType::class, [
                     'choices' => [
-                        'public' => 'form.label_mode_public',
-                        'admin' => 'form.label_mode_admin',
+                        'form.label_mode_public' => 'public',
+                        'form.label_mode_admin' => 'admin',
                     ],
                     'label' => 'form.label_mode',
                 ]],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong translation in blocks

```