### PR TITLE
Add compatibility with FOSRest 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "symfony/templating": "^2.8 || ^3.2 || ^4.0"
     },
     "conflict": {
+        "friendsofsymfony/rest-bundle": "<1.8 || >=3.0",
         "jms/serializer": "<0.13",
         "sonata-project/block-bundle": "<3.11",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
@@ -54,8 +55,8 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
-        "friendsofsymfony/rest-bundle": "^1.1",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "friendsofsymfony/rest-bundle": "^1.8 || ^2.1",
+        "jms/serializer-bundle": "^1.0 || ^2.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",

--- a/src/Controller/Api/CommentController.php
+++ b/src/Controller/Api/CommentController.php
@@ -44,14 +44,14 @@ class CommentController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="comment id"}
      *  },
-     *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when comment is not found"
      *  }
      * )
      *
-     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @REST\Route(requirements={"_format"="json|xml"})
      *

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -309,7 +309,7 @@ class PostController
         $comment->setPost($post);
 
         $form = $this->formFactory->createNamed(null, 'sonata_news_api_form_comment', $comment, ['csrf_protection' => false]);
-        $form->bind($request);
+        $form->handleRequest($request);
 
         if ($form->isValid()) {
             $comment = $form->getData();
@@ -378,7 +378,7 @@ class PostController
             'csrf_protection' => false,
         ]);
 
-        $form->bind($request);
+        $form->handleRequest($request);
 
         if ($form->isValid()) {
             $comment = $form->getData();
@@ -459,7 +459,7 @@ class PostController
             'csrf_protection' => false,
         ]);
 
-        $form->bind($request);
+        $form->handleRequest($request);
 
         if ($form->isValid()) {
             $post = $form->getData();

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -12,10 +12,10 @@
 namespace Sonata\NewsBundle\Controller\Api;
 
 use Application\Sonata\NewsBundle\Entity\Post;
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations as REST;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\FormatterBundle\Formatter\Pool as FormatterPool;
@@ -92,7 +92,7 @@ class PostController
      * @REST\QueryParam(name="author", requirements="\S+", nullable=true, strict=true, description="Author filter")
      * @REST\QueryParam(name="mode", requirements="public|admin", default="public", description="'public' mode filters posts having enabled tags and author")
      *
-     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @REST\Route(requirements={"_format"="json|xml"})
      *
@@ -124,7 +124,7 @@ class PostController
      *  }
      * )
      *
-     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @REST\Route(requirements={"_format"="json|xml"})
      *
@@ -246,7 +246,7 @@ class PostController
      *
      * @REST\Route(requirements={"_format"="json|xml"})
      *
-     * @REST\View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param int                   $id           A post identifier
      * @param ParamFetcherInterface $paramFetcher
@@ -286,6 +286,8 @@ class PostController
      *  }
      * )
      *
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
+     *
      * @REST\Route(requirements={"_format"="json|xml"})
      *
      * @param int     $id      A post identifier
@@ -320,13 +322,7 @@ class PostController
             $this->commentManager->save($comment);
             $this->mailer->sendCommentNotification($comment);
 
-            $view = View::create($comment);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(['sonata_api_read']);
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $comment;
         }
 
         return $form;
@@ -348,6 +344,8 @@ class PostController
      *      404="Returned when unable to find comment"
      *  }
      * )
+     *
+     * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @REST\Route(requirements={"_format"="json|xml"})
      *
@@ -386,13 +384,7 @@ class PostController
             $comment = $form->getData();
             $this->commentManager->save($comment);
 
-            $view = View::create($comment);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(['sonata_api_read']);
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
-
-            return $view;
+            return $comment;
         }
 
         return $form;
@@ -474,11 +466,18 @@ class PostController
             $post->setContent($this->formatterPool->transform($post->getContentFormatter(), $post->getRawContent()));
             $this->postManager->save($post);
 
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
+
+            // simplify when dropping FOSRest < 2.1
+            if (method_exists($context, 'enableMaxDepth')) {
+                $context->enableMaxDepth();
+            } else {
+                $context->setMaxDepth(10);
+            }
+
             $view = View::create($post);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(['sonata_api_read']);
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
+            $view->setContext($context);
 
             return $view;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Compatibility with FOSRest 2.0
### Fixed
- Replaced deprecated `bind` by `handleRequest` on forms
```

## Subject

<!-- Describe your Pull Request content here -->
Since this bundle is not even compatible with FOSRest 2.0 let's add that first before removing compat with 1.0.

Also bind was deprecated like a lot of years ago, instead use handleRequest: https://github.com/symfony/symfony/blob/2.4/UPGRADE-3.0.md#form

This bundle is also waiting for FOSUserBundle to be compatible with 4.0