### PR TITLE
Update installation.rst

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -7,6 +7,7 @@ Installation
 
     composer require sonata-project/news-bundle sonata-project/doctrine-orm-admin-bundle
 
+If you encounter a problem with egeloen/ckeditor-bundle during installation, review the documentation here: https://sonata-project.org/bundles/formatter/master/doc/reference/installation.html
 
 If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``.
 


### PR DESCRIPTION
I encountered this issue and it was resolved. See this for context: https://stackoverflow.com/questions/50729247/sonatanewsbundle-throws-error-on-composer-require

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is an issue with the current documentation that blocks users for installing the newsbundle



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
Clarification to installation doc to unblock users
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
