### PR TITLE
Use ADR pattern

### DIFF
--- a/src/Action/AbstractPostArchiveAction.php
+++ b/src/Action/AbstractPostArchiveAction.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AbstractPostArchiveAction extends Controller
+{
+    /**
+     * @var BlogInterface
+     */
+    private $blog;
+
+    /**
+     * @var PostManagerInterface
+     */
+    private $postManager;
+
+    public function __construct(BlogInterface $blog, PostManagerInterface $postManager)
+    {
+        $this->blog = $blog;
+        $this->postManager = $postManager;
+    }
+
+    /**
+     * @internal
+     *
+     * NEXT_MAJOR: make this method protected
+     *
+     * @return Response
+     */
+    final public function renderArchive(Request $request, array $criteria = [], array $parameters = [])
+    {
+        $pager = $this->postManager->getPager(
+            $criteria,
+            $request->get('page', 1)
+        );
+
+        $parameters = array_merge([
+            'pager' => $pager,
+            'blog' => $this->blog,
+            'tag' => false,
+            'collection' => false,
+            'route' => $request->get('_route'),
+            'route_parameters' => $request->get('_route_params'),
+        ], $parameters);
+
+        $response = $this->render(
+            sprintf('@SonataNews/Post/archive.%s.twig', $request->getRequestFormat()),
+            $parameters
+        );
+
+        if ('rss' === $request->getRequestFormat()) {
+            $response->headers->set('Content-Type', 'application/rss+xml');
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return PostManagerInterface
+     */
+    final protected function getPostManager()
+    {
+        return $this->postManager;
+    }
+}

--- a/src/Action/CollectionPostArchiveAction.php
+++ b/src/Action/CollectionPostArchiveAction.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\ClassificationBundle\Model\CollectionManagerInterface;
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class CollectionPostArchiveAction extends AbstractPostArchiveAction
+{
+    /**
+     * @var CollectionManagerInterface
+     */
+    private $collectionManager;
+
+    public function __construct(
+        BlogInterface $blog,
+        PostManagerInterface $postManager,
+        CollectionManagerInterface $collectionManager
+    ) {
+        parent::__construct($blog, $postManager);
+
+        $this->collectionManager = $collectionManager;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request, $tag)
+    {
+        $collection = $this->collectionManager->findOneBy([
+            'slug' => $tag,
+            'enabled' => true,
+        ]);
+
+        if (!$collection || !$collection->getEnabled()) {
+            throw new NotFoundHttpException('Unable to find the collection');
+        }
+
+        return $this->renderArchive($request, ['collection' => $collection], ['collection' => $collection]);
+    }
+}

--- a/src/Action/CommentListAction.php
+++ b/src/Action/CommentListAction.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Model\CommentInterface;
+use Sonata\NewsBundle\Model\CommentManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CommentListAction extends Controller
+{
+    /**
+     * @var CommentManagerInterface
+     */
+    private $commentManager;
+
+    public function __construct(CommentManagerInterface $commentManager)
+    {
+        $this->commentManager = $commentManager;
+    }
+
+    /**
+     * @param int $postId
+     *
+     * @return Response
+     */
+    public function __invoke($postId)
+    {
+        $pager = $this->commentManager
+            ->getPager([
+                'postId' => $postId,
+                'status' => CommentInterface::STATUS_VALID,
+            ], 1, 500); //no limit
+
+        return $this->render('@SonataNews/Post/comments.html.twig', [
+            'pager' => $pager,
+        ]);
+    }
+}

--- a/src/Action/CreateCommentAction.php
+++ b/src/Action/CreateCommentAction.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Form\Type\CommentType;
+use Sonata\NewsBundle\Mailer\MailerInterface;
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\CommentManagerInterface;
+use Sonata\NewsBundle\Model\PostInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+final class CreateCommentAction extends Controller
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var BlogInterface
+     */
+    private $blog;
+
+    /**
+     * @var PostManagerInterface
+     */
+    private $postManager;
+
+    /**
+     * @var CommentManagerInterface
+     */
+    private $commentManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var MailerInterface
+     */
+    private $mailer;
+
+    public function __construct(
+        RouterInterface $router,
+        BlogInterface $blog,
+        PostManagerInterface $postManager,
+        CommentManagerInterface $commentManager,
+        FormFactoryInterface $formFactory,
+        MailerInterface $mailer
+    ) {
+        $this->router = $router;
+        $this->blog = $blog;
+        $this->postManager = $postManager;
+        $this->commentManager = $commentManager;
+        $this->formFactory = $formFactory;
+        $this->mailer = $mailer;
+    }
+
+    /**
+     * @param string  $id
+     * @param Request $request
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request, $id)
+    {
+        $post = $this->postManager->findOneBy([
+            'id' => $id,
+        ]);
+
+        if (!$post) {
+            throw new NotFoundHttpException(sprintf('Post (%d) not found', $id));
+        }
+
+        if (!$post->isCommentable()) {
+            // todo add notice.
+            return new RedirectResponse($this->router->generate('sonata_news_view', [
+                'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
+            ]));
+        }
+
+        $form = $this->getCommentForm($post);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $comment = $form->getData();
+
+            $this->commentManager->save($comment);
+            $this->mailer->sendCommentNotification($comment);
+
+            // todo : add notice
+            return new RedirectResponse($this->router->generate('sonata_news_view', [
+                'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
+            ]));
+        }
+
+        return $this->render('@SonataNews/Post/view.html.twig', [
+            'post' => $post,
+            'form' => $form,
+        ]);
+    }
+
+    /**
+     * @return FormInterface
+     */
+    private function getCommentForm(PostInterface $post)
+    {
+        $comment = $this->commentManager->create();
+        $comment->setPost($post);
+        $comment->setStatus($post->getCommentsDefaultStatus());
+
+        return $this->formFactory->createNamed('comment', CommentType::class, $comment, [
+            'action' => $this->router->generate('sonata_news_add_comment', [
+                'id' => $post->getId(),
+            ]),
+            'method' => 'POST',
+        ]);
+    }
+}

--- a/src/Action/CreateCommentFormAction.php
+++ b/src/Action/CreateCommentFormAction.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Form\Type\CommentType;
+use Sonata\NewsBundle\Model\CommentManagerInterface;
+use Sonata\NewsBundle\Model\PostInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+final class CreateCommentFormAction extends Controller
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var PostManagerInterface
+     */
+    private $postManager;
+
+    /**
+     * @var CommentManagerInterface
+     */
+    private $commentManager;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    public function __construct(
+        RouterInterface $router,
+        PostManagerInterface $postManager,
+        CommentManagerInterface $commentManager,
+        FormFactoryInterface $formFactory
+    ) {
+        $this->router = $router;
+        $this->postManager = $postManager;
+        $this->commentManager = $commentManager;
+        $this->formFactory = $formFactory;
+    }
+
+    /**
+     * @param string $postId
+     * @param bool   $form
+     *
+     * @return Response
+     */
+    public function __invoke($postId, $form = false)
+    {
+        if (!$form) {
+            $post = $this->postManager->findOneBy([
+                'id' => $postId,
+            ]);
+
+            $form = $this->getCommentForm($post);
+        }
+
+        return $this->render('@SonataNews/Post/comment_form.html.twig', [
+            'form' => $form->createView(),
+            'post_id' => $postId,
+        ]);
+    }
+
+    /**
+     * @return FormInterface
+     */
+    private function getCommentForm(PostInterface $post)
+    {
+        $comment = $this->commentManager->create();
+        $comment->setPost($post);
+        $comment->setStatus($post->getCommentsDefaultStatus());
+
+        return $this->formFactory->createNamed('comment', CommentType::class, $comment, [
+            'action' => $this->router->generate('sonata_news_add_comment', [
+                'id' => $post->getId(),
+            ]),
+            'method' => 'POST',
+        ]);
+    }
+}

--- a/src/Action/ModerateCommentAction.php
+++ b/src/Action/ModerateCommentAction.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\CommentManagerInterface;
+use Sonata\NewsBundle\Util\HashGeneratorInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class ModerateCommentAction
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var BlogInterface
+     */
+    private $blog;
+
+    /**
+     * @var CommentManagerInterface
+     */
+    private $commentManager;
+
+    /**
+     * @var HashGeneratorInterface
+     */
+    private $hashGenerator;
+
+    public function __construct(
+        RouterInterface $router,
+        BlogInterface $blog,
+        CommentManagerInterface $commentManager,
+        HashGeneratorInterface $hashGenerator
+    ) {
+        $this->router = $router;
+        $this->blog = $blog;
+        $this->commentManager = $commentManager;
+        $this->hashGenerator = $hashGenerator;
+    }
+
+    /**
+     * @param string $commentId
+     * @param string $hash
+     * @param string $status
+     *
+     * @throws AccessDeniedException
+     *
+     * @return RedirectResponse
+     */
+    public function __invoke($commentId, $hash, $status)
+    {
+        $comment = $this->commentManager->findOneBy(['id' => $commentId]);
+
+        if (!$comment) {
+            throw new AccessDeniedException();
+        }
+
+        $computedHash = $this->hashGenerator->generate($comment);
+
+        if ($computedHash != $hash) {
+            throw new AccessDeniedException();
+        }
+
+        $comment->setStatus($status);
+
+        $this->commentManager->save($comment);
+
+        return new RedirectResponse($this->router->generate('sonata_news_view', [
+            'permalink' => $this->blog->getPermalinkGenerator()->generate($comment->getPost()),
+        ]));
+    }
+}

--- a/src/Action/MonthlyPostArchiveAction.php
+++ b/src/Action/MonthlyPostArchiveAction.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class MonthlyPostArchiveAction extends AbstractPostArchiveAction
+{
+    /**
+     * @param string $year
+     * @param string $month
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request, $year, $month)
+    {
+        return $this->renderArchive($request, [
+            'date' => $this->getPostManager()->getPublicationDateQueryParts(
+                sprintf('%d-%d-%d', $year, $month, 1),
+                'month'
+            ),
+        ], []);
+    }
+}

--- a/src/Action/PostArchiveAction.php
+++ b/src/Action/PostArchiveAction.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PostArchiveAction extends AbstractPostArchiveAction
+{
+    /**
+     * @return Response
+     */
+    public function __invoke(Request $request)
+    {
+        return $this->renderArchive($request);
+    }
+}

--- a/src/Action/TagPostArchiveAction.php
+++ b/src/Action/TagPostArchiveAction.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\ClassificationBundle\Model\TagManagerInterface;
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class TagPostArchiveAction extends AbstractPostArchiveAction
+{
+    /**
+     * @var TagManagerInterface
+     */
+    private $tagManager;
+
+    public function __construct(BlogInterface $blog, PostManagerInterface $postManager, TagManagerInterface $tagManager)
+    {
+        parent::__construct($blog, $postManager);
+
+        $this->tagManager = $tagManager;
+    }
+
+    /**
+     * @param string $tag
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request, $tag)
+    {
+        $tag = $this->tagManager->findOneBy([
+            'slug' => $tag,
+            'enabled' => true,
+        ]);
+
+        if (!$tag || !$tag->getEnabled()) {
+            throw new NotFoundHttpException('Unable to find the tag');
+        }
+
+        return $this->renderArchive($request, ['tag' => $tag->getSlug()], ['tag' => $tag]);
+    }
+}

--- a/src/Action/ViewPostAction.php
+++ b/src/Action/ViewPostAction.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ViewPostAction extends Controller
+{
+    /**
+     * @var BlogInterface
+     */
+    private $blog;
+
+    /**
+     * @var PostManagerInterface
+     */
+    private $postManager;
+
+    /**
+     * @var SeoPageInterface|null
+     */
+    private $seoPage;
+
+    public function __construct(BlogInterface $blog, PostManagerInterface $postManager)
+    {
+        $this->blog = $blog;
+        $this->postManager = $postManager;
+    }
+
+    /**
+     * @param string $permalink
+     *
+     * @throws NotFoundHttpException
+     *
+     * @return Response
+     */
+    public function __invoke($permalink)
+    {
+        $post = $this->postManager->findOneByPermalink($permalink, $this->blog);
+
+        if (!$post || !$post->isPublic()) {
+            throw new NotFoundHttpException('Unable to find the post');
+        }
+
+        if ($seoPage = $this->seoPage) {
+            $seoPage
+                ->setTitle($post->getTitle())
+                ->addMeta('name', 'description', $post->getAbstract())
+                ->addMeta('property', 'og:title', $post->getTitle())
+                ->addMeta('property', 'og:type', 'blog')
+                ->addMeta('property', 'og:url', $this->generateUrl('sonata_news_view', [
+                    'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
+                ], UrlGeneratorInterface::ABSOLUTE_URL))
+                ->addMeta('property', 'og:description', $post->getAbstract())
+            ;
+        }
+
+        return $this->render('@SonataNews/Post/view.html.twig', [
+            'post' => $post,
+            'form' => false,
+            'blog' => $this->blog,
+        ]);
+    }
+
+    /**
+     * @param null|SeoPageInterface $seoPage
+     */
+    public function setSeoPage(SeoPageInterface $seoPage = null)
+    {
+        $this->seoPage = $seoPage;
+    }
+}

--- a/src/Action/YearlyPostArchiveAction.php
+++ b/src/Action/YearlyPostArchiveAction.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Action;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class YearlyPostArchiveAction extends AbstractPostArchiveAction
+{
+    /**
+     * @param string $year
+     *
+     * @return Response
+     */
+    public function __invoke(Request $request, $year)
+    {
+        return $this->renderArchive($request, [
+            'date' => $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, 1, 1), 'year'),
+        ], []);
+    }
+}

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -11,9 +11,26 @@
 
 namespace Sonata\NewsBundle\Controller;
 
+// NEXT_MAJOR: remove this file
+
+@trigger_error(
+    'The '.__NAMESPACE__.'\PostController class is deprecated since version 3.x and will be removed in 4.0.'
+    .' Use '.__NAMESPACE__.'\Action\* classes instead.',
+    E_USER_DEPRECATED
+);
+
+use Sonata\NewsBundle\Action\CollectionPostArchiveAction;
+use Sonata\NewsBundle\Action\CommentListAction;
+use Sonata\NewsBundle\Action\CreateCommentAction;
+use Sonata\NewsBundle\Action\CreateCommentFormAction;
+use Sonata\NewsBundle\Action\ModerateCommentAction;
+use Sonata\NewsBundle\Action\MonthlyPostArchiveAction;
+use Sonata\NewsBundle\Action\PostArchiveAction;
+use Sonata\NewsBundle\Action\TagPostArchiveAction;
+use Sonata\NewsBundle\Action\ViewPostAction;
+use Sonata\NewsBundle\Action\YearlyPostArchiveAction;
 use Sonata\NewsBundle\Form\Type\CommentType;
 use Sonata\NewsBundle\Model\BlogInterface;
-use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
@@ -24,7 +41,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class PostController extends Controller
@@ -46,29 +62,9 @@ class PostController extends Controller
      */
     public function renderArchive(array $criteria = [], array $parameters = [], Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(PostArchiveAction::class);
 
-        $pager = $this->getPostManager()->getPager(
-            $criteria,
-            $request->get('page', 1)
-        );
-
-        $parameters = array_merge([
-            'pager' => $pager,
-            'blog' => $this->getBlog(),
-            'tag' => false,
-            'collection' => false,
-            'route' => $request->get('_route'),
-            'route_parameters' => $request->get('_route_params'),
-        ], $parameters);
-
-        $response = $this->render(sprintf('@SonataNews/Post/archive.%s.twig', $request->getRequestFormat()), $parameters);
-
-        if ('rss' === $request->getRequestFormat()) {
-            $response->headers->set('Content-Type', 'application/rss+xml');
-        }
-
-        return $response;
+        return $action->renderArchive($this->resolveRequest($request), $criteria, $parameters);
     }
 
     /**
@@ -78,7 +74,9 @@ class PostController extends Controller
      */
     public function archiveAction(Request $request = null)
     {
-        return $this->renderArchive();
+        $action = $this->container->get(PostArchiveAction::class);
+
+        return $action($this->resolveRequest($request));
     }
 
     /**
@@ -91,18 +89,9 @@ class PostController extends Controller
      */
     public function tagAction($tag, Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(TagPostArchiveAction::class);
 
-        $tag = $this->get('sonata.classification.manager.tag')->findOneBy([
-            'slug' => $tag,
-            'enabled' => true,
-        ]);
-
-        if (!$tag || !$tag->getEnabled()) {
-            throw new NotFoundHttpException('Unable to find the tag');
-        }
-
-        return $this->renderArchive(['tag' => $tag->getSlug()], ['tag' => $tag], $request);
+        return $action($this->resolveRequest($request), $tag);
     }
 
     /**
@@ -115,18 +104,9 @@ class PostController extends Controller
      */
     public function collectionAction($collection, Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(CollectionPostArchiveAction::class);
 
-        $collection = $this->get('sonata.classification.manager.collection')->findOneBy([
-            'slug' => $collection,
-            'enabled' => true,
-        ]);
-
-        if (!$collection || !$collection->getEnabled()) {
-            throw new NotFoundHttpException('Unable to find the collection');
-        }
-
-        return $this->renderArchive(['collection' => $collection], ['collection' => $collection], $request);
+        return $action($this->resolveRequest($request), $collection);
     }
 
     /**
@@ -138,11 +118,9 @@ class PostController extends Controller
      */
     public function archiveMonthlyAction($year, $month, Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(MonthlyPostArchiveAction::class);
 
-        return $this->renderArchive([
-            'date' => $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, $month, 1), 'month'),
-        ], [], $request);
+        return $action($this->resolveRequest($request), $year, $month);
     }
 
     /**
@@ -153,11 +131,9 @@ class PostController extends Controller
      */
     public function archiveYearlyAction($year, Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(YearlyPostArchiveAction::class);
 
-        return $this->renderArchive([
-            'date' => $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, 1, 1), 'year'),
-        ], [], $request);
+        return $action($this->resolveRequest($request), $year);
     }
 
     /**
@@ -169,30 +145,9 @@ class PostController extends Controller
      */
     public function viewAction($permalink)
     {
-        $post = $this->getPostManager()->findOneByPermalink($permalink, $this->getBlog());
+        $action = $this->container->get(ViewPostAction::class);
 
-        if (!$post || !$post->isPublic()) {
-            throw new NotFoundHttpException('Unable to find the post');
-        }
-
-        if ($seoPage = $this->getSeoPage()) {
-            $seoPage
-                ->setTitle($post->getTitle())
-                ->addMeta('name', 'description', $post->getAbstract())
-                ->addMeta('property', 'og:title', $post->getTitle())
-                ->addMeta('property', 'og:type', 'blog')
-                ->addMeta('property', 'og:url', $this->generateUrl('sonata_news_view', [
-                    'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post),
-                ], UrlGeneratorInterface::ABSOLUTE_URL))
-                ->addMeta('property', 'og:description', $post->getAbstract())
-            ;
-        }
-
-        return $this->render('@SonataNews/Post/view.html.twig', [
-            'post' => $post,
-            'form' => false,
-            'blog' => $this->getBlog(),
-        ]);
+        return $action($permalink);
     }
 
     /**
@@ -214,15 +169,9 @@ class PostController extends Controller
      */
     public function commentsAction($postId)
     {
-        $pager = $this->getCommentManager()
-            ->getPager([
-                'postId' => $postId,
-                'status' => CommentInterface::STATUS_VALID,
-            ], 1, 500); //no limit
+        $action = $this->container->get(CommentListAction::class);
 
-        return $this->render('@SonataNews/Post/comments.html.twig', [
-            'pager' => $pager,
-        ]);
+        return $action($postId);
     }
 
     /**
@@ -233,18 +182,9 @@ class PostController extends Controller
      */
     public function addCommentFormAction($postId, $form = false)
     {
-        if (!$form) {
-            $post = $this->getPostManager()->findOneBy([
-                'id' => $postId,
-            ]);
+        $action = $this->container->get(CreateCommentFormAction::class);
 
-            $form = $this->getCommentForm($post);
-        }
-
-        return $this->render('@SonataNews/Post/comment_form.html.twig', [
-            'form' => $form->createView(),
-            'post_id' => $postId,
-        ]);
+        return $action($postId, $form);
     }
 
     /**
@@ -276,42 +216,9 @@ class PostController extends Controller
      */
     public function addCommentAction($id, Request $request = null)
     {
-        $request = $this->resolveRequest($request);
+        $action = $this->container->get(CreateCommentAction::class);
 
-        $post = $this->getPostManager()->findOneBy([
-            'id' => $id,
-        ]);
-
-        if (!$post) {
-            throw new NotFoundHttpException(sprintf('Post (%d) not found', $id));
-        }
-
-        if (!$post->isCommentable()) {
-            // todo add notice.
-            return new RedirectResponse($this->generateUrl('sonata_news_view', [
-                'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post),
-            ]));
-        }
-
-        $form = $this->getCommentForm($post);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $comment = $form->getData();
-
-            $this->getCommentManager()->save($comment);
-            $this->get('sonata.news.mailer')->sendCommentNotification($comment);
-
-            // todo : add notice
-            return new RedirectResponse($this->generateUrl('sonata_news_view', [
-                'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($post),
-            ]));
-        }
-
-        return $this->render('@SonataNews/Post/view.html.twig', [
-            'post' => $post,
-            'form' => $form,
-        ]);
+        return $action($this->resolveRequest($request), $id);
     }
 
     /**
@@ -325,25 +232,9 @@ class PostController extends Controller
      */
     public function commentModerationAction($commentId, $hash, $status)
     {
-        $comment = $this->getCommentManager()->findOneBy(['id' => $commentId]);
+        $action = $this->container->get(ModerateCommentAction::class);
 
-        if (!$comment) {
-            throw new AccessDeniedException();
-        }
-
-        $computedHash = $this->get('sonata.news.hash.generator')->generate($comment);
-
-        if ($computedHash != $hash) {
-            throw new AccessDeniedException();
-        }
-
-        $comment->setStatus($status);
-
-        $this->getCommentManager()->save($comment);
-
-        return new RedirectResponse($this->generateUrl('sonata_news_view', [
-            'permalink' => $this->getBlog()->getPermalinkGenerator()->generate($comment->getPost()),
-        ]));
+        return $action($commentId, $hash, $status);
     }
 
     /**

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -39,6 +39,7 @@ class SonataNewsExtension extends Extension
         $bundles = $container->getParameter('kernel.bundles');
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('actions.xml');
         $loader->load('orm.xml');
         $loader->load('twig.xml');
         $loader->load('form.xml');

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- NEXT_MAJOR: remove the "class" and "public" attributes -->
+        <service id="Sonata\NewsBundle\Action\CollectionPostArchiveAction" class="Sonata\NewsBundle\Action\CollectionPostArchiveAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="sonata.classification.manager.collection"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\TagPostArchiveAction" class="Sonata\NewsBundle\Action\TagPostArchiveAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="sonata.classification.manager.tag"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\YearlyPostArchiveAction" class="Sonata\NewsBundle\Action\YearlyPostArchiveAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\MonthlyPostArchiveAction" class="Sonata\NewsBundle\Action\MonthlyPostArchiveAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\PostArchiveAction" class="Sonata\NewsBundle\Action\PostArchiveAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\ViewPostAction" class="Sonata\NewsBundle\Action\ViewPostAction" public="true">
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <call method="setSeoPage">
+                <argument type="service" id="sonata.seo.page" on-invalid="null"/>
+            </call>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\ModerateCommentAction" class="Sonata\NewsBundle\Action\ModerateCommentAction" public="true">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.comment"/>
+            <argument type="service" id="sonata.news.hash.generator"/>
+        </service>
+        <service id="Sonata\NewsBundle\Action\CommentListAction" class="Sonata\NewsBundle\Action\CommentListAction" public="true">
+            <argument type="service" id="sonata.news.manager.comment"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\CreateCommentAction" class="Sonata\NewsBundle\Action\CreateCommentAction" public="true">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.news.blog"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="sonata.news.manager.comment"/>
+            <argument type="service" id="form.factory"/>
+            <argument type="service" id="sonata.news.mailer"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+        <service id="Sonata\NewsBundle\Action\CreateCommentFormAction" class="Sonata\NewsBundle\Action\CreateCommentFormAction" public="true">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="sonata.news.manager.comment"/>
+            <argument type="service" id="form.factory"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/routing/news.xml
+++ b/src/Resources/config/routing/news.xml
@@ -1,46 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_news_add_comment" path="/add-comment/{id}">
-        <default key="_controller">SonataNewsBundle:Post:addComment</default>
+        <default key="_controller">Sonata\NewsBundle\Action\CreateCommentAction</default>
     </route>
     <route id="sonata_news_archive_monthly" path="/archive/{year}/{month}.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:archiveMonthly</default>
+        <default key="_controller">Sonata\NewsBundle\Action\MonthlyPostArchiveAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
         <requirement key="year">\d+</requirement>
         <requirement key="month">\d+</requirement>
     </route>
     <route id="sonata_news_tag" path="/tag/{tag}.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:tag</default>
+        <default key="_controller">Sonata\NewsBundle\Action\TagPostArchiveAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
     </route>
     <route id="sonata_news_collection" path="/collection/{collection}.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:collection</default>
+        <default key="_controller">Sonata\NewsBundle\Action\CollectionPostArchiveAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
     </route>
     <route id="sonata_news_archive_yearly" path="/archive/{year}.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:archiveYearly</default>
+        <default key="_controller">Sonata\NewsBundle\Action\YearlyPostArchiveAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
         <requirement key="year">\d+</requirement>
     </route>
     <route id="sonata_news_archive" path="/archive.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:archive</default>
+        <default key="_controller">Sonata\NewsBundle\Action\PostArchiveAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
     </route>
     <route id="sonata_news_comment_moderation" path="/comment/moderation/{commentId}/{hash}/{status}">
-        <default key="_controller">SonataNewsBundle:Post:commentModeration</default>
+        <default key="_controller">Sonata\NewsBundle\Action\ModerateCommentAction</default>
     </route>
     <route id="sonata_news_view" path="/{permalink}.{_format}">
-        <default key="_controller">SonataNewsBundle:Post:view</default>
+        <default key="_controller">Sonata\NewsBundle\Action\ViewPostAction</default>
         <default key="_format">html</default>
         <requirement key="_format">html|rss</requirement>
         <requirement key="permalink">.+?</requirement>
     </route>
     <route id="sonata_news_home" path="/">
-        <default key="_controller">SonataNewsBundle:Post:home</default>
+        <default key="_controller">Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction</default>
+        <default key="route">sonata_news_archive</default>
     </route>
 </routes>

--- a/src/Resources/views/Post/view.html.twig
+++ b/src/Resources/views/Post/view.html.twig
@@ -60,7 +60,7 @@
     {{ render(controller('SonataNewsBundle:Post:comments', {'postId': post.id})) }}
 
     {% if post.iscommentable %}
-        {{ render(controller('SonataNewsBundle:Post:addCommentForm', {
+        {{ render(controller('Sonata\\NewsBundle\\Action\\CreateCommentFormAction', {
             'postId': post.id,
             'form': form
         })) }}


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- `Controller\PostController` is now deprecated in favor of `Action\*Action`
```

## Todo
- [x] add `NEXT_MAJOR` comments
- [x] move to `Action` namespace
- [x] test this on an actual project

## Subject

Using invokable CaaSes vs one big controller achieves several things:
1. it discourages piling on more actions in controllers with vague names (SRP)
2. it leads to easier to unit test actions and visible deps (DIP)
3. it will allow us to make more services private

Refs https://github.com/sonata-project/SonataAdminBundle/pull/5120
