### PR TITLE
Fix deprecations for addChild

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "sonata-project/admin-bundle": "^3.31",
+        "sonata-project/admin-bundle": "^3.35",
         "sonata-project/classification-bundle": "^3.6",
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/datagrid-bundle": "^2.3",

--- a/src/Admin/CommentAdmin.php
+++ b/src/Admin/CommentAdmin.php
@@ -23,8 +23,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CommentAdmin extends AbstractAdmin
 {
-    protected $parentAssociationMapping = 'post';
-
     /**
      * @var CommentManagerInterface
      */

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -14,6 +14,7 @@
             </call>
             <call method="addChild">
                 <argument type="service" id="sonata.news.admin.comment"/>
+                <argument>post</argument>
             </call>
             <call method="setTranslationDomain">
                 <argument>%sonata.news.admin.post.translation_domain%</argument>


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Fixed
- Fixed `addChild` deprecations
```

## Subject

After merging https://github.com/sonata-project/SonataAdminBundle/pull/5058 all the bundles that used `addChild` are now throwing deprecations, this fixes it.

Also i removed `$parentAssociationMapping` property from `CommentAdmin` as it must not be a string by default.