### PR TITLE
Make posts visible to admins with status message

### DIFF
--- a/src/Action/ViewPostAction.php
+++ b/src/Action/ViewPostAction.php
@@ -12,12 +12,14 @@
 namespace Sonata\NewsBundle\Action;
 
 use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class ViewPostAction extends Controller
 {
@@ -32,14 +34,23 @@ final class ViewPostAction extends Controller
     private $postManager;
 
     /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authChecker;
+
+    /**
      * @var SeoPageInterface|null
      */
     private $seoPage;
 
-    public function __construct(BlogInterface $blog, PostManagerInterface $postManager)
-    {
+    public function __construct(
+        BlogInterface $blog,
+        PostManagerInterface $postManager,
+        AuthorizationCheckerInterface $authChecker
+    ) {
         $this->blog = $blog;
         $this->postManager = $postManager;
+        $this->authChecker = $authChecker;
     }
 
     /**
@@ -83,5 +94,15 @@ final class ViewPostAction extends Controller
     public function setSeoPage(SeoPageInterface $seoPage = null)
     {
         $this->seoPage = $seoPage;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isVisible(PostInterface $post)
+    {
+        return $post->isPublic() ||
+            $this->authChecker->isGranted('ROLE_SUPER_ADMIN') ||
+            $this->authChecker->isGranted('ROLE_SONATA_NEWS_ADMIN_POST_EDIT');
     }
 }

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -42,6 +42,7 @@
         <service id="Sonata\NewsBundle\Action\ViewPostAction" class="Sonata\NewsBundle\Action\ViewPostAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="security.authorization_checker"/>
             <call method="setSeoPage">
                 <argument type="service" id="sonata.seo.page" on-invalid="null"/>
             </call>

--- a/src/Resources/translations/SonataNewsBundle.de.xliff
+++ b/src/Resources/translations/SonataNewsBundle.de.xliff
@@ -487,6 +487,14 @@
                 <source>form.label_class</source>
                 <target>CSS Klasse</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Schließen</target>
+            </trans-unit>
+            <trans-unit id="post_is_disabled">
+                <source>post_is_disabled</source>
+                <target>News ist noch nicht freigeschaltet.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataNewsBundle.en.xliff
+++ b/src/Resources/translations/SonataNewsBundle.en.xliff
@@ -479,6 +479,14 @@ Quick moderation links :
                 <source>form.label_class</source>
                 <target>CSS Class</target>
             </trans-unit>
+            <trans-unit id="message_close">
+                <source>message_close</source>
+                <target>Close</target>
+            </trans-unit>
+            <trans-unit id="post_is_disabled">
+                <source>post_is_disabled</source>
+                <target>Post is not public.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/views/Post/view.html.twig
+++ b/src/Resources/views/Post/view.html.twig
@@ -19,6 +19,16 @@
     </div>
 {% endblock %}
 
+
+{% if not post.isPublic %}
+    <div class="alert alert-danger alert-fixed">
+        <button type="button" class="close" data-dismiss="alert"
+                aria-label="{{ 'message_close'|trans({}, 'SonataNewsBundle') }}"
+        >&times;</button>
+        <i class="fa fa-eye-slash" aria-hidden="true"></i> {{ 'post_is_disabled'|trans({}, 'SonataNewsBundle') }}
+    </div>
+{% endif %}
+
 <article class="sonata-blog-post-container">
     <header>
         <div class="sonata-blog-post-date-container">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC if not tag is created before merging this.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Make posts visible to admins
- Show status message if post is not public
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

This PR makes all posts visible to admins and show a status information:
<img width="1134" alt="screen shot 2018-06-20 at 07 50 20" src="https://user-images.githubusercontent.com/3440437/41639584-aa11ec86-745e-11e8-9120-3252203ab9b6.PNG">

