### PR TITLE
Add SEO information to archives

### DIFF
--- a/src/Action/AbstractPostArchiveAction.php
+++ b/src/Action/AbstractPostArchiveAction.php
@@ -13,9 +13,11 @@ namespace Sonata\NewsBundle\Action;
 
 use Sonata\NewsBundle\Model\BlogInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
 
 abstract class AbstractPostArchiveAction extends Controller
 {
@@ -29,10 +31,21 @@ abstract class AbstractPostArchiveAction extends Controller
      */
     private $postManager;
 
-    public function __construct(BlogInterface $blog, PostManagerInterface $postManager)
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var SeoPageInterface|null
+     */
+    private $seoPage;
+
+    public function __construct(BlogInterface $blog, PostManagerInterface $postManager, TranslatorInterface $translator)
     {
         $this->blog = $blog;
         $this->postManager = $postManager;
+        $this->translator = $translator;
     }
 
     /**
@@ -68,6 +81,42 @@ abstract class AbstractPostArchiveAction extends Controller
         }
 
         return $response;
+    }
+
+    /**
+     * @param null|SeoPageInterface $seoPage
+     */
+    public function setSeoPage(SeoPageInterface $seoPage = null)
+    {
+        $this->seoPage = $seoPage;
+    }
+
+    /**
+     * @param string      $id
+     * @param string|null $domain
+     * @param string|null $locale
+     *
+     * @return string
+     */
+    final protected function trans($id, array $parameters = [], $domain = 'SonataNewsBundle', $locale = null)
+    {
+        return $this->translator->trans($id, $parameters, $domain, $locale);
+    }
+
+    /**
+     * @return BlogInterface
+     */
+    final protected function getBlog()
+    {
+        return $this->blog;
+    }
+
+    /**
+     * @return null|SeoPageInterface
+     */
+    final protected function getSeoPage()
+    {
+        return $this->seoPage;
     }
 
     /**

--- a/src/Action/CollectionPostArchiveAction.php
+++ b/src/Action/CollectionPostArchiveAction.php
@@ -17,6 +17,7 @@ use Sonata\NewsBundle\Model\PostManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Translation\TranslatorInterface;
 
 final class CollectionPostArchiveAction extends AbstractPostArchiveAction
 {
@@ -28,9 +29,10 @@ final class CollectionPostArchiveAction extends AbstractPostArchiveAction
     public function __construct(
         BlogInterface $blog,
         PostManagerInterface $postManager,
+        TranslatorInterface $translator,
         CollectionManagerInterface $collectionManager
     ) {
-        parent::__construct($blog, $postManager);
+        parent::__construct($blog, $postManager, $translator);
 
         $this->collectionManager = $collectionManager;
     }
@@ -49,6 +51,28 @@ final class CollectionPostArchiveAction extends AbstractPostArchiveAction
 
         if (!$collection || !$collection->getEnabled()) {
             throw new NotFoundHttpException('Unable to find the collection');
+        }
+
+        if ($seoPage = $this->getSeoPage()) {
+            $seoPage
+                ->setTitle($this->trans('archive_collection.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%collection%' => $collection->getName(),
+                ]))
+                ->addMeta('property', 'og:title', $this->trans('archive_collection.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%collection%' => $collection->getName(),
+                ]))
+                ->addMeta('name', 'description', $this->trans('archive_collection.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%collection%' => $collection->getName(),
+                    '%description%' => $collection->getDescription(),
+                ]))
+                ->addMeta('property', 'og:description', $this->trans('archive_collection.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%collection%' => $collection->getName(),
+                    '%description%' => $collection->getDescription(),
+                ]));
         }
 
         return $this->renderArchive($request, ['collection' => $collection], ['collection' => $collection]);

--- a/src/Action/MonthlyPostArchiveAction.php
+++ b/src/Action/MonthlyPostArchiveAction.php
@@ -11,11 +11,31 @@
 
 namespace Sonata\NewsBundle\Action;
 
+use Sonata\IntlBundle\Templating\Helper\DateTimeHelper;
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\PostManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
 
 final class MonthlyPostArchiveAction extends AbstractPostArchiveAction
 {
+    /**
+     * @var DateTimeHelper
+     */
+    private $dateTimeHelper;
+
+    public function __construct(
+        BlogInterface $blog,
+        PostManagerInterface $postManager,
+        TranslatorInterface $translator,
+        DateTimeHelper $dateTimeHelper
+    ) {
+        parent::__construct($blog, $postManager, $translator);
+
+        $this->dateTimeHelper = $dateTimeHelper;
+    }
+
     /**
      * @param string $year
      * @param string $month
@@ -24,11 +44,36 @@ final class MonthlyPostArchiveAction extends AbstractPostArchiveAction
      */
     public function __invoke(Request $request, $year, $month)
     {
+        $date = $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, $month, 1), 'month');
+
+        if ($seoPage = $this->getSeoPage()) {
+            $seoPage
+                ->setTitle($this->trans('archive_month.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%month%' => $this->dateTimeHelper->format($date, 'MMMM'),
+                ]))
+                ->addMeta('property', 'og:title', $this->trans('archive_month.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%month%' => $this->dateTimeHelper->format($date, 'MMMM'),
+                ]))
+                ->addMeta('name', 'description', $this->trans('archive_month.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%month%' => $this->dateTimeHelper->format($date, 'MMMM'),
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]))
+                ->addMeta('property', 'og:description', $this->trans('archive_month.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%month%' => $this->dateTimeHelper->format($date, 'MMMM'),
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]));
+        }
+
         return $this->renderArchive($request, [
-            'date' => $this->getPostManager()->getPublicationDateQueryParts(
-                sprintf('%d-%d-%d', $year, $month, 1),
-                'month'
-            ),
+            'date' => $date,
         ], []);
     }
 }

--- a/src/Action/PostArchiveAction.php
+++ b/src/Action/PostArchiveAction.php
@@ -21,6 +21,24 @@ final class PostArchiveAction extends AbstractPostArchiveAction
      */
     public function __invoke(Request $request)
     {
+        if ($seoPage = $this->getSeoPage()) {
+            $seoPage
+                ->setTitle($this->trans('archive.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                ]))
+                ->addMeta('property', 'og:title', $this->trans('archive.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                ]))
+                ->addMeta('name', 'description', $this->trans('archive.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]))
+                ->addMeta('property', 'og:description', $this->trans('archive.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]));
+        }
+
         return $this->renderArchive($request);
     }
 }

--- a/src/Action/TagPostArchiveAction.php
+++ b/src/Action/TagPostArchiveAction.php
@@ -17,6 +17,7 @@ use Sonata\NewsBundle\Model\PostManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Translation\TranslatorInterface;
 
 final class TagPostArchiveAction extends AbstractPostArchiveAction
 {
@@ -25,9 +26,13 @@ final class TagPostArchiveAction extends AbstractPostArchiveAction
      */
     private $tagManager;
 
-    public function __construct(BlogInterface $blog, PostManagerInterface $postManager, TagManagerInterface $tagManager)
-    {
-        parent::__construct($blog, $postManager);
+    public function __construct(
+        BlogInterface $blog,
+        PostManagerInterface $postManager,
+        TranslatorInterface $translator,
+        TagManagerInterface $tagManager
+    ) {
+        parent::__construct($blog, $postManager, $translator);
 
         $this->tagManager = $tagManager;
     }
@@ -46,6 +51,26 @@ final class TagPostArchiveAction extends AbstractPostArchiveAction
 
         if (!$tag || !$tag->getEnabled()) {
             throw new NotFoundHttpException('Unable to find the tag');
+        }
+
+        if ($seoPage = $this->getSeoPage()) {
+            $seoPage
+                ->setTitle($this->trans('archive_tag.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%tag%' => $tag->getName(),
+                ]))
+                ->addMeta('property', 'og:title', $this->trans('archive_tag.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%tag%' => $tag->getName(),
+                ]))
+                ->addMeta('name', 'description', $this->trans('archive_tag.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%tag%' => $tag->getName(),
+                ]))
+                ->addMeta('property', 'og:description', $this->trans('archive_tag.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%tag%' => $tag->getName(),
+                ]));
         }
 
         return $this->renderArchive($request, ['tag' => $tag->getSlug()], ['tag' => $tag]);

--- a/src/Action/YearlyPostArchiveAction.php
+++ b/src/Action/YearlyPostArchiveAction.php
@@ -23,8 +23,32 @@ final class YearlyPostArchiveAction extends AbstractPostArchiveAction
      */
     public function __invoke(Request $request, $year)
     {
+        $date = $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, 1, 1), 'year');
+
+        if ($seoPage = $this->getSeoPage()) {
+            $seoPage
+                ->setTitle($this->trans('archive_year.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                ]))
+                ->addMeta('property', 'og:title', $this->trans('archive_year.meta_title', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                ]))
+                ->addMeta('name', 'description', $this->trans('archive_year.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]))
+                ->addMeta('property', 'og:description', $this->trans('archive_year.meta_description', [
+                    '%title%' => $this->getBlog()->getTitle(),
+                    '%year%' => $year,
+                    '%description%' => $this->getBlog()->getDescription(),
+                ]));
+        }
+
         return $this->renderArchive($request, [
-            'date' => $this->getPostManager()->getPublicationDateQueryParts(sprintf('%d-%d-%d', $year, 1, 1), 'year'),
+            'date' => $date,
         ], []);
     }
 }

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -5,7 +5,11 @@
         <service id="Sonata\NewsBundle\Action\CollectionPostArchiveAction" class="Sonata\NewsBundle\Action\CollectionPostArchiveAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="sonata.classification.manager.collection"/>
+            <call method="setSeoPage">
+                <argument type="service" id="sonata.seo.page" on-invalid="null"/>
+            </call>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -13,7 +17,11 @@
         <service id="Sonata\NewsBundle\Action\TagPostArchiveAction" class="Sonata\NewsBundle\Action\TagPostArchiveAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="sonata.classification.manager.tag"/>
+            <call method="setSeoPage">
+                <argument type="service" id="sonata.seo.page" on-invalid="null"/>
+            </call>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -21,6 +29,10 @@
         <service id="Sonata\NewsBundle\Action\YearlyPostArchiveAction" class="Sonata\NewsBundle\Action\YearlyPostArchiveAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="translator"/>
+            <call method="setSeoPage">
+                <argument type="service" id="sonata.seo.page" on-invalid="null"/>
+            </call>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -28,6 +40,11 @@
         <service id="Sonata\NewsBundle\Action\MonthlyPostArchiveAction" class="Sonata\NewsBundle\Action\MonthlyPostArchiveAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="translator"/>
+            <argument type="service" id="sonata.intl.templating.helper.datetime"/>
+            <call method="setSeoPage">
+                <argument type="service" id="sonata.seo.page" on-invalid="null"/>
+            </call>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>
@@ -35,6 +52,7 @@
         <service id="Sonata\NewsBundle\Action\PostArchiveAction" class="Sonata\NewsBundle\Action\PostArchiveAction" public="true">
             <argument type="service" id="sonata.news.blog"/>
             <argument type="service" id="sonata.news.manager.post"/>
+            <argument type="service" id="translator"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Resources/translations/SonataNewsBundle.de.xliff
+++ b/src/Resources/translations/SonataNewsBundle.de.xliff
@@ -495,6 +495,46 @@
                 <source>post_is_disabled</source>
                 <target>News ist noch nicht freigeschaltet.</target>
             </trans-unit>
+            <trans-unit id="archive.meta_title">
+                <source>archive.meta_title</source>
+                <target>Archiv</target>
+            </trans-unit>
+            <trans-unit id="archive.meta_description">
+                <source>archive.meta_description</source>
+                <target>Archiv</target>
+            </trans-unit>
+            <trans-unit id="archive_month.meta_title">
+                <source>archive_month.meta_title</source>
+                <target>Archiv von %month% %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_month.meta_description">
+                <source>archive_month.meta_description</source>
+                <target>Archiv von %month% %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_year.meta_title">
+                <source>archive_year.meta_title</source>
+                <target>Archiv von %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_year.meta_description">
+                <source>archive_year.meta_description</source>
+                <target>Archiv von %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_collection.meta_title">
+                <source>archive_collection.meta_title</source>
+                <target>Archiv der %collection% Sammlung</target>
+            </trans-unit>
+            <trans-unit id="archive_collection.meta_description">
+                <source>archive_collection.meta_description</source>
+                <target>%description%</target>
+            </trans-unit>
+            <trans-unit id="archive_tag.meta_title">
+                <source>archive_tag.meta_title</source>
+                <target>Archiv für %tag%</target>
+            </trans-unit>
+            <trans-unit id="archive_tag.meta_description">
+                <source>archive_tag.meta_description</source>
+                <target>Archiv für %tag%</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataNewsBundle.en.xliff
+++ b/src/Resources/translations/SonataNewsBundle.en.xliff
@@ -479,6 +479,46 @@ Quick moderation links :
                 <source>form.label_class</source>
                 <target>CSS Class</target>
             </trans-unit>
+            <trans-unit id="archive.meta_title">
+                <source>archive.meta_title</source>
+                <target>Archive</target>
+            </trans-unit>
+            <trans-unit id="archive.meta_description">
+                <source>archive.meta_description</source>
+                <target>Archive</target>
+            </trans-unit>
+            <trans-unit id="archive_month.meta_title">
+                <source>archive_month.meta_title</source>
+                <target>Archive of %month% %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_month.meta_description">
+                <source>archive_month.meta_description</source>
+                <target>Archive of %month% %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_year.meta_title">
+                <source>archive_year.meta_title</source>
+                <target>Archive of %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_year.meta_description">
+                <source>archive_year.meta_description</source>
+                <target>Archive of %year%</target>
+            </trans-unit>
+            <trans-unit id="archive_collection.meta_title">
+                <source>archive_collection.meta_title</source>
+                <target>Archive of %collection% collection</target>
+            </trans-unit>
+            <trans-unit id="archive_collection.meta_description">
+                <source>archive_collection.meta_description</source>
+                <target>%description%</target>
+            </trans-unit>
+            <trans-unit id="archive_tag.meta_title">
+                <source>archive_tag.meta_title</source>
+                <target>Archive for %tag%</target>
+            </trans-unit>
+            <trans-unit id="archive_tag.meta_description">
+                <source>archive_tag.meta_description</source>
+                <target>Archive for %tag%</target>
+            </trans-unit>
             <trans-unit id="message_close">
                 <source>message_close</source>
                 <target>Close</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC if not tag is created before merging this.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added SEO information to archives
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
-->

## To do
- [x] Update translation

## Subject

Adds more SEO information to archive pafges.
