### PR TITLE
Ensure inheritance system works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ cs-fix-xml:
 .PHONY: cs-fix-xml
 
 test:
-	phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml
+	php test.php
 .PHONY: test
 
 docs:

--- a/test.php
+++ b/test.php
@@ -1,0 +1,13 @@
+<?php
+
+use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\NewsBundle\Admin\CommentAdmin;
+
+require 'vendor/autoload.php';
+
+class Test extends CommentAdmin
+{
+    public function setCommentManager(ManagerInterface $commentManager)
+    {
+    }
+}


### PR DESCRIPTION
Don't merge, I'm just making sure the new type hints will not cause crashes on php 7.1