### PR TITLE
Documentation : Remove Tag and Collection from sonata news configuration file

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -34,14 +34,6 @@ Advanced Configuration
                 class:       Sonata\NewsBundle\Admin\CommentAdmin
                 controller:  SonataNewsBundle:CommentAdmin
                 translation: SonataNewsBundle
-            collection:
-                class:       Sonata\NewsBundle\Admin\CollectionAdmin
-                controller:  SonataAdminBundle:CRUD
-                translation: SonataNewsBundle
-            tag:
-                class:       Sonata\NewsBundle\Admin\TagAdmin
-                controller:  SonataAdminBundle:CRUD
-                translation: SonataNewsBundle
 
 .. code-block:: yaml
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Remove Tag and Collection from sonata news configuration file otherwise it's just not working :

> Unrecognized  option "tag" under "sonata_news.admin". Available options are "comment", "post".


I am targeting this branch, because this is a documentation fix.


