### PR TITLE
Trigger an error if a class declaration is missing in the configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "doctrine/orm": "^2.4",
         "friendsofsymfony/rest-bundle": "^1.8 || ^2.1",
         "jms/serializer-bundle": "^1.0 || ^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "nelmio/api-doc-bundle": "^2.4",
         "sonata-project/block-bundle": "^3.14",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -24,6 +24,8 @@ Advanced Configuration
             comment:    Application\Sonata\NewsBundle\Entity\Comment
             media:      Application\Sonata\MediaBundle\Entity\Media
             user:       Application\Sonata\UserBundle\Entity\User
+            tag:        Application\Sonata\ClassificationBundle\Entity\Tag
+            collection: Application\Sonata\ClassificationBundle\Entity\Collection
 
         admin:
             post:

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -141,6 +141,11 @@ class SonataNewsExtension extends Extension
 
         foreach ($config['class'] as $type => $class) {
             if (!class_exists($class)) {
+                /**
+                 * NEXT_MAJOR: Uncomment this method
+                 *
+                 * Throw an exception if the class is not defined
+                 */
                 @trigger_error('The class '.$class.' is not defined or doesn\'t exist. This is tolerated now but will be forbidden in 4.0', E_USER_DEPRECATED);
 
                 return;

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -145,7 +145,10 @@ class SonataNewsExtension extends Extension
                  * NEXT_MAJOR:
                  * Throw an exception if the class is not defined
                  */
-                @trigger_error('The class '.$class.' is not defined or doesn\'t exist. This is tolerated now but will be forbidden in 4.0', E_USER_DEPRECATED);
+                @trigger_error(sprintf(
+                    'The "%s" class is not defined or does not exist. This is tolerated now but will be forbidden in 4.0',
+                    $class
+                ), E_USER_DEPRECATED);
 
                 return;
             }

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -141,6 +141,8 @@ class SonataNewsExtension extends Extension
 
         foreach ($config['class'] as $type => $class) {
             if (!class_exists($class)) {
+                @trigger_error('The class '.$class.' is not defined or doesn\'t exist. This is tolerated now but will be forbidden in 4.0', E_USER_DEPRECATED);
+
                 return;
             }
         }

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -142,7 +142,7 @@ class SonataNewsExtension extends Extension
         foreach ($config['class'] as $type => $class) {
             if (!class_exists($class)) {
                 /*
-                 * NEXT_MAJOR: 
+                 * NEXT_MAJOR:
                  * Throw an exception if the class is not defined
                  */
                 @trigger_error('The class '.$class.' is not defined or doesn\'t exist. This is tolerated now but will be forbidden in 4.0', E_USER_DEPRECATED);

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -141,9 +141,8 @@ class SonataNewsExtension extends Extension
 
         foreach ($config['class'] as $type => $class) {
             if (!class_exists($class)) {
-                /**
-                 * NEXT_MAJOR: Uncomment this method
-                 *
+                /*
+                 * NEXT_MAJOR: 
                  * Throw an exception if the class is not defined
                  */
                 @trigger_error('The class '.$class.' is not defined or doesn\'t exist. This is tolerated now but will be forbidden in 4.0', E_USER_DEPRECATED);

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -25,7 +25,6 @@ use Sonata\UserBundle\Model\User;
 
 class SonataNewsExtensionTest extends AbstractExtensionTestCase
 {
-    
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\MediaBundle\Model\Media;
+use Sonata\NewsBundle\DependencyInjection\SonataNewsExtension;
+use Sonata\NewsBundle\Model\Comment;
+use Sonata\NewsBundle\Model\Post;
+use Sonata\UserBundle\Model\User;
+
+class SonataNewsExtensionTest extends AbstractExtensionTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', []);
+    }
+
+    /**
+     * Test if the deprecation notice is trigger when the tag (or collection) class declaration is missing.
+     * It should trigger a deprecation notice but doesn't break anything
+     * You should have 0 associations.
+     *
+     * @group legacy
+     * @expectedDeprecation The class %s is not defined or doesn't exist. This is tolerated now but will be forbidden in 4.0
+     */
+    public function testLoadWithoutTagWithoutCollection(): void
+    {
+        $this->load($this->getMinimalConfiguration());
+        $collector = DoctrineCollector::getInstance();
+
+        $this->assertEmpty($collector->getAssociations());
+    }
+
+    /**
+     * Test if the deprecation notice is trigger when the tag (or collection) class declaration is present.
+     * It shouldn't trigger a deprecation notice but doesn't break anything
+     * You should have 2 associations (Post, Comment).
+     * The Post model should have an associations with (Media, User, Collection, Tag).
+     */
+    public function testLoadWithTagWithCollection(): void
+    {
+        $minimalConfiguration = $this->getMinimalConfiguration();
+        $tagAndCollectionDeclaration = [
+                'class' => [
+                        'collection' => \stdClass::class,
+                        'tag' => \stdClass::class,
+                ],
+            ];
+        $this->load(array_merge($minimalConfiguration, $tagAndCollectionDeclaration));
+        $collector = DoctrineCollector::getInstance();
+        //assert our model have associations
+        $this->assertSame(2, count($collector->getAssociations()));
+        $postManyToOneAssociation = $collector->getAssociations()[Post::class]['mapManyToOne'];
+        //assert the post model has  3 many to one associations (user,media,collection)
+        $this->assertSame(3, count($postManyToOneAssociation));
+        $postManyToManyAssociation = $collector->getAssociations()[Post::class]['mapManyToMany'];
+        //assert the post model has  1 many to many associations (tag)
+        $this->assertSame(1, count($postManyToManyAssociation));
+        $postOneToManyAssociation = $collector->getAssociations()[Post::class]['mapOneToMany'];
+        //assert the post model has  1 one to many associations (comment)
+        $this->assertSame(1, count($postOneToManyAssociation));
+    }
+
+    public function getMinimalConfiguration(): array
+    {
+        return [
+                'title' => 'Foo title',
+                'link' => '/foo/bar',
+                'description' => 'Foo description',
+                'salt' => 'pepper',
+                'comment' => [
+                    'notification' => [
+                        'emails' => ['email@example.org', 'email2@example.org'],
+                        'from' => 'no-reply@sonata-project.org',
+                        'template' => '@SonataNews/Mail/comment_notification.txt.twig',
+                    ],
+                ],
+                'class' => [
+                    'post' => Post::class,
+                    'comment' => Comment::class,
+                    'media' => Media::class,
+                    'user' => User::class,
+                ],
+            ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions()
+    {
+        return [
+            new SonataNewsExtension(),
+        ];
+    }
+}

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -33,7 +33,7 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
-     * Test if the deprecation notice is trigger when the tag (or collection) class declaration is missing.
+     * Test if the deprecation notice is triggered when the tag (or collection) class declaration is missing.
      * It should trigger a deprecation notice but doesn't break anything
      * You should have 0 associations.
      *

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -25,9 +25,7 @@ use Sonata\UserBundle\Model\User;
 
 class SonataNewsExtensionTest extends AbstractExtensionTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
+    
     protected function setUp(): void
     {
         parent::setUp();
@@ -105,9 +103,6 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
         return array_merge($minimalConfiguration, $tagAndCollectionDeclaration);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getContainerExtensions()
     {
         return [

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -49,10 +49,10 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
-     * Test if the deprecation notice is trigger when the tag (or collection) class declaration is present.
+     * Test if the deprecation notice is triggered when the tag (or collection) class declaration is present.
      * It shouldn't trigger a deprecation notice but doesn't break anything
      * You should have 2 associations (Post, Comment).
-     * The Post model should have an associations with (Media, User, Collection, Tag).
+     * The Post model should have an association with (Media, User, Collection, Tag).
      */
     public function testLoadWithTagWithCollection(): void
     {
@@ -65,16 +65,16 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
             ];
         $this->load(array_merge($minimalConfiguration, $tagAndCollectionDeclaration));
         $collector = DoctrineCollector::getInstance();
-        //assert our model have associations
+        // assert our model has associations
         $this->assertCount(2, $collector->getAssociations());
         $postManyToOneAssociation = $collector->getAssociations()[Post::class]['mapManyToOne'];
-        //assert the post model has  3 many to one associations (user,media,collection)
+        // assert the post model has 3 many to one associations (user, media, collection)
         $this->assertCount(3, $postManyToOneAssociation);
         $postManyToManyAssociation = $collector->getAssociations()[Post::class]['mapManyToMany'];
-        //assert the post model has  1 many to many associations (tag)
+        // assert the post model has 1 many to many association (tag)
         $this->assertCount(1, $postManyToManyAssociation);
         $postOneToManyAssociation = $collector->getAssociations()[Post::class]['mapOneToMany'];
-        //assert the post model has  1 one to many associations (comment)
+        // assert the post model has 1 one to many association (comment)
         $this->assertCount(1, $postOneToManyAssociation);
     }
 

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -66,16 +66,16 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
         $this->load(array_merge($minimalConfiguration, $tagAndCollectionDeclaration));
         $collector = DoctrineCollector::getInstance();
         //assert our model have associations
-        $this->assertSame(2, count($collector->getAssociations()));
+        $this->assertCount(2, $collector->getAssociations());
         $postManyToOneAssociation = $collector->getAssociations()[Post::class]['mapManyToOne'];
         //assert the post model has  3 many to one associations (user,media,collection)
-        $this->assertSame(3, count($postManyToOneAssociation));
+        $this->assertCount(3, $postManyToOneAssociation);
         $postManyToManyAssociation = $collector->getAssociations()[Post::class]['mapManyToMany'];
         //assert the post model has  1 many to many associations (tag)
-        $this->assertSame(1, count($postManyToManyAssociation));
+        $this->assertCount(1, $postManyToManyAssociation);
         $postOneToManyAssociation = $collector->getAssociations()[Post::class]['mapOneToMany'];
         //assert the post model has  1 one to many associations (comment)
-        $this->assertSame(1, count($postOneToManyAssociation));
+        $this->assertCount(1, $postOneToManyAssociation);
     }
 
     public function getMinimalConfiguration(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
According the issue #517 we have to add more controls in order to prevent people to forget the tag and the collection class declarations.
That's why I add some information in the documentation and I add a trigger_error message.
Moreover I created a new test class : SonataNewsExtensionTest to test this PR.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this pull request is backwards comptatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #517 , #385 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added a new test class SonataNewsExtensionTest. Inspired by the SonataMediaExtensionTest, I extended AbstractExtensionTestCase to test if the association with media, user, tag, collection have been created according to a configuration
- A dependency to [matthiasnoback/symfony-dependency-injection-test
](https://packagist.org/packages/matthiasnoback/symfony-dependency-injection-test) 

### Changed
- src/DependencyInjection/SonataNewsExtension.php registerDoctrineMapping to add a trigger_error message
```


_this is my first PR, sorry if I forgot something_