### PR TITLE
 Added events to comment action 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/event-dispatcher": "^3.4 || ^4.0",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",

--- a/src/Action/CreateCommentAction.php
+++ b/src/Action/CreateCommentAction.php
@@ -90,7 +90,7 @@ final class CreateCommentAction extends Controller
             'id' => $id,
         ]);
 
-        if (!$post) {
+        if (!$post instanceof PostInterface) {
             throw new NotFoundHttpException(sprintf('Post (%d) not found', $id));
         }
 

--- a/src/Action/CreateCommentAction.php
+++ b/src/Action/CreateCommentAction.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Action;
 
+use Sonata\NewsBundle\Event\FilterCommentResponseEvent;
+use Sonata\NewsBundle\Event\FormEvent;
+use Sonata\NewsBundle\Event\GetResponseCommentEvent;
 use Sonata\NewsBundle\Form\Type\CommentType;
 use Sonata\NewsBundle\Mailer\MailerInterface;
 use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
+use Sonata\NewsBundle\SonataNewsEvents;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -60,13 +66,20 @@ final class CreateCommentAction extends Controller
      */
     private $mailer;
 
+    /**
+     * @var EventDispatcherInterface|null
+     */
+    private $eventDispatcher;
+
+    // NEXT_MAJOR: Make $eventDispatcher a required dependency
     public function __construct(
         RouterInterface $router,
         BlogInterface $blog,
         PostManagerInterface $postManager,
         CommentManagerInterface $commentManager,
         FormFactoryInterface $formFactory,
-        MailerInterface $mailer
+        MailerInterface $mailer,
+        EventDispatcherInterface $eventDispatcher = null
     ) {
         $this->router = $router;
         $this->blog = $blog;
@@ -74,6 +87,14 @@ final class CreateCommentAction extends Controller
         $this->commentManager = $commentManager;
         $this->formFactory = $formFactory;
         $this->mailer = $mailer;
+        $this->eventDispatcher = $eventDispatcher;
+
+        if (null === $this->eventDispatcher) {
+            @trigger_error(sprintf(
+                'Not providing an event dispatcher to %s is deprecated since sonata-project/news-bundle 3.x',
+                __CLASS__
+            ), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -95,25 +116,53 @@ final class CreateCommentAction extends Controller
         }
 
         if (!$post->isCommentable()) {
-            // todo add notice.
+            // todo : add notice in event listener
             return new RedirectResponse($this->router->generate('sonata_news_view', [
                 'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
             ]));
         }
 
-        $form = $this->getCommentForm($post);
+        $comment = $this->createComment($post);
+
+        // NEXT_MAJOR: Remove the if code
+        if (null !== $this->eventDispatcher) {
+            $event = new GetResponseCommentEvent($comment, $request);
+            $this->eventDispatcher->dispatch(SonataNewsEvents::COMMENT_INITIALIZE, $event);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+        }
+
+        $form = $this->getCommentForm($comment);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            // NEXT_MAJOR: Remove the if code
+            if (null !== $this->eventDispatcher) {
+                $event = new FormEvent($form, $request);
+                $this->eventDispatcher->dispatch(SonataNewsEvents::COMMENT_SUCCESS, $event);
+            }
+
             $comment = $form->getData();
 
             $this->commentManager->save($comment);
             $this->mailer->sendCommentNotification($comment);
 
-            // todo : add notice
-            return new RedirectResponse($this->router->generate('sonata_news_view', [
+            // todo : add notice in event listener
+            $response = new RedirectResponse($this->router->generate('sonata_news_view', [
                 'permalink' => $this->blog->getPermalinkGenerator()->generate($post),
             ]));
+
+            // NEXT_MAJOR: Remove the if code
+            if (null !== $this->eventDispatcher) {
+                $this->eventDispatcher->dispatch(
+                    SonataNewsEvents::COMMENT_COMPLETED,
+                    new FilterCommentResponseEvent($comment, $request, $response)
+                );
+            }
+
+            return $response;
         }
 
         return $this->render('@SonataNews/Post/view.html.twig', [
@@ -122,20 +171,22 @@ final class CreateCommentAction extends Controller
         ]);
     }
 
-    /**
-     * @return FormInterface
-     */
-    private function getCommentForm(PostInterface $post)
+    private function getCommentForm(CommentInterface $comment): FormInterface
+    {
+        return $this->formFactory->createNamed('comment', CommentType::class, $comment, [
+            'action' => $this->router->generate('sonata_news_add_comment', [
+                'id' => $comment->getPost()->getId(),
+            ]),
+            'method' => 'POST',
+        ]);
+    }
+
+    private function createComment(PostInterface $post): CommentInterface
     {
         $comment = $this->commentManager->create();
         $comment->setPost($post);
         $comment->setStatus($post->getCommentsDefaultStatus());
 
-        return $this->formFactory->createNamed('comment', CommentType::class, $comment, [
-            'action' => $this->router->generate('sonata_news_add_comment', [
-                'id' => $post->getId(),
-            ]),
-            'method' => 'POST',
-        ]);
+        return $comment;
     }
 }

--- a/src/Event/CommentEvent.php
+++ b/src/Event/CommentEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Event;
+
+use Sonata\NewsBundle\Model\CommentInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class CommentEvent extends Event
+{
+    /**
+     * @var Request|null
+     */
+    private $request;
+
+    /**
+     * @var CommentInterface
+     */
+    private $comment;
+
+    public function __construct(CommentInterface $comment, ?Request $request = null)
+    {
+        $this->comment = $comment;
+        $this->request = $request;
+    }
+
+    final public function getComment(): CommentInterface
+    {
+        return $this->comment;
+    }
+
+    final public function getRequest(): ?Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Event/FilterCommentResponseEvent.php
+++ b/src/Event/FilterCommentResponseEvent.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Event;
+
+use Sonata\NewsBundle\Model\CommentInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FilterCommentResponseEvent extends CommentEvent
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    public function __construct(CommentInterface $comment, Request $request, Response $response)
+    {
+        parent::__construct($comment, $request);
+
+        $this->response = $response;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function setResponse(Response $response): void
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Event/FormEvent.php
+++ b/src/Event/FormEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FormEvent extends Event
+{
+    /**
+     * @var FormInterface
+     */
+    private $form;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var Response|null
+     */
+    private $response;
+
+    public function __construct(FormInterface $form, Request $request)
+    {
+        $this->form = $form;
+        $this->request = $request;
+    }
+
+    public function getForm(): FormInterface
+    {
+        return $this->form;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function setResponse(Response $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/GetResponseCommentEvent.php
+++ b/src/Event/GetResponseCommentEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class GetResponseCommentEvent extends CommentEvent
+{
+    /**
+     * @var Response|null
+     */
+    private $response;
+
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+
+    public function setResponse(?Response $response): void
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -102,6 +102,7 @@
             <argument type="service" id="sonata.news.manager.comment"/>
             <argument type="service" id="form.factory"/>
             <argument type="service" id="sonata.news.mailer"/>
+            <argument type="service" id="event_dispatcher"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/SonataNewsEvents.php
+++ b/src/SonataNewsEvents.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle;
+
+final class SonataNewsEvents
+{
+    /**
+     * The COMMENT_INITIALIZE event occurs when the comment process is initialized.
+     *
+     * This event allows you to modify the default values of the comment before binding the form.
+     *
+     * @Event("Sonata\NewsBundle\Event\CommentEvent")
+     */
+    public const COMMENT_INITIALIZE = 'sonata_news.comment.initialize';
+
+    /**
+     * The COMMENT_SUCCESS event occurs when the comment form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\NewsBundle\Event\FormEvent")
+     */
+    public const COMMENT_SUCCESS = 'sonata_news.comment.success';
+
+    /**
+     * The COMMENT_COMPLETED event occurs after saving the comment in the comment process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\NewsBundle\Event\FilterCommentResponseEvent")
+     */
+    public const COMMENT_COMPLETED = 'sonata_news.comment.completed';
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Added events to the comment action. This is a great start for custom comment filtering or extending the comment before processing it.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added events to the comment process 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
