### PR TITLE
[Docs] Missing "FOS CKEditor" default config

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -88,6 +88,16 @@ Default configuration
                         #ApplicationSonataNewsBundle: ~
                         SonataNewsBundle: ~
 
+* Define default ``news`` FOS CKEditor configuration
+
+.. code-block:: yaml
+
+    # config/packages/fos_ckeditor.yaml
+
+    fos_ck_editor:
+        configs:
+            news: ~
+
 * Add a new context into your ``sonata_media.yml`` configuration if you don't have go there https://sonata-project.org/bundles/media/master/doc/reference/installation.html:
 
 .. code-block:: yaml


### PR DESCRIPTION
Updated missing information about basic setup for "FOS CKEditor" ``news`` context configuration

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there's no information in SonataNewsBundle [setup docs](https://sonata-project.org/bundles/news/3-x/doc/reference/installation.html) about basic [required context in ``PostAdmin.php``] configuration for "FOS CKEditor" bundle.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #482

