### PR TITLE
Twig deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
         "symfony/routing": "^2.8 || ^3.2 || ^4.0",
         "symfony/security-core": "^2.8 || ^3.2 || ^4.0",
-        "symfony/templating": "^2.8 || ^3.2 || ^4.0"
+        "symfony/templating": "^2.8 || ^3.2 || ^4.0",
+        "twig/twig": "^1.35 || ^2.4"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",

--- a/src/Twig/Extension/NewsExtension.php
+++ b/src/Twig/Extension/NewsExtension.php
@@ -19,8 +19,12 @@ use Sonata\NewsBundle\Model\BlogInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\InitRuntimeInterface;
+use Twig\TwigFunction;
 
-class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+class NewsExtension extends AbstractExtension implements InitRuntimeInterface
 {
     /**
      * @var RouterInterface
@@ -33,7 +37,7 @@ class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     private $tagManager;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $environment;
 
@@ -71,11 +75,11 @@ class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'sonata_news_link_tag_rss',
                 [$this, 'renderTagRss', ['is_safe' => ['html']]]
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'sonata_news_permalink',
                 [$this, 'generatePermalink']
             ),
@@ -85,7 +89,7 @@ class NewsExtension extends \Twig_Extension implements \Twig_Extension_InitRunti
     /**
      * {@inheritdoc}
      */
-    public function initRuntime(\Twig_Environment $environment)
+    public function initRuntime(Environment $environment)
     {
         $this->environment = $environment;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fixing Twig deprecation notice in Symfony 4

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add missing `twig/twig` required in `composer.json` with versions `^1.35 || ^2.4`

### Fixed
* deprecation notice about using namespaced classes from `\Twig\`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
