### PR TITLE
Add default context to breadcrumbs 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "doctrine/dbal": "<2.6.0",
         "friendsofsymfony/rest-bundle": "<1.8 || >=3.0",
         "jms/serializer": "<0.13",
-        "sonata-project/block-bundle": "<3.14",
+        "sonata-project/block-bundle": "<3.18",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
         "sonata-project/seo-bundle": "<2.0 || >=3.0"
@@ -63,7 +63,7 @@
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "nelmio/api-doc-bundle": "^2.4",
-        "sonata-project/block-bundle": "^3.14",
+        "sonata-project/block-bundle": "^3.18",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -16,7 +16,7 @@
             <argument type="service" id="sonata.admin.pool" on-invalid="ignore"/>
         </service>
         <service id="sonata.news.block.breadcrumb_archive" class="Sonata\NewsBundle\Block\Breadcrumb\NewsArchiveBreadcrumbBlockService" public="true">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="breadcrumb"/>
             <tag name="sonata.breadcrumb"/>
             <argument>news_archive</argument>
             <argument>sonata.news.block.breadcrumb_archive</argument>
@@ -25,7 +25,7 @@
             <argument type="service" id="knp_menu.factory"/>
         </service>
         <service id="sonata.news.block.breadcrumb_post" class="Sonata\NewsBundle\Block\Breadcrumb\NewsPostBreadcrumbBlockService" public="true">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="breadcrumb"/>
             <tag name="sonata.breadcrumb"/>
             <argument>news_post</argument>
             <argument>sonata.news.block.breadcrumb_post</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add default context to breadcrumbs 
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
