### PR TITLE
Explicitly indicate version of required nelmio/api-doc-bundle

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -16,7 +16,7 @@ If you want to use the API, you also need ``friendsofsymfony/rest-bundle`` and `
 
 .. code-block:: bash
 
-    composer require nelmio/api-doc-bundle
+    composer require nelmio/api-doc-bundle:^2.10
 
     composer require friendsofsymfony/rest-bundle
 


### PR DESCRIPTION
By default composer installs `v3` and this error occurs:

An exception has been thrown during the rendering of a template ("[Semantical Error] The annotation "@Nelmio\ApiDocBundle\Annotation\ApiDoc" in method Sonata\NewsBundle\Controller\Api\PostController::getPostsAction() does not exist, or could not be auto-loaded in Sonata\NewsBundle\Controller\Api\PostController (which is being imported from "/www/config/routes/routes.yaml").").


