### PR TITLE
Add nelmio/api-doc-bundle versions conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,11 +52,11 @@
         "doctrine/dbal": "<2.6.0",
         "friendsofsymfony/rest-bundle": "<1.8 || >=3.0",
         "jms/serializer": "<0.13",
+        "nelmio/api-doc-bundle": "<2.0 || >=3.0",
         "sonata-project/block-bundle": "<3.18",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
-        "sonata-project/seo-bundle": "<2.0 || >=3.0",
-        "nelmio/api-doc-bundle": "<2.0 || >=3.0"
+        "sonata-project/seo-bundle": "<2.0 || >=3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
@@ -71,10 +71,10 @@
         "symfony/phpunit-bridge": "^4.3"
     },
     "suggest": {
+        "nelmio/api-doc-bundle": "^2.0",
         "sonata-project/block-bundle": "For rendering block lists.",
         "sonata-project/doctrine-orm-admin-bundle": "^2.2",
-        "sonata-project/notification-bundle": "^2.2",
-        "nelmio/api-doc-bundle": "^2.0"
+        "sonata-project/notification-bundle": "^2.2"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "symfony/phpunit-bridge": "^4.3"
     },
     "suggest": {
-        "nelmio/api-doc-bundle": "^2.0",
+        "nelmio/api-doc-bundle": "If you want to use the API",
         "sonata-project/block-bundle": "For rendering block lists.",
         "sonata-project/doctrine-orm-admin-bundle": "^2.2",
         "sonata-project/notification-bundle": "^2.2"

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "sonata-project/block-bundle": "<3.18",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
-        "sonata-project/seo-bundle": "<2.0 || >=3.0"
+        "sonata-project/seo-bundle": "<2.0 || >=3.0",
+        "nelmio/api-doc-bundle": "<2.0 || >=3.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4",
@@ -72,7 +73,8 @@
     "suggest": {
         "sonata-project/block-bundle": "For rendering block lists.",
         "sonata-project/doctrine-orm-admin-bundle": "^2.2",
-        "sonata-project/notification-bundle": "^2.2"
+        "sonata-project/notification-bundle": "^2.2",
+        "nelmio/api-doc-bundle": "^2.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

By default composer installs v3 and this error occurs:

An exception has been thrown during the rendering of a template ("[Semantical Error] The annotation "@nelmio\ApiDocBundle\Annotation\ApiDoc" in method Sonata\NewsBundle\Controller\Api\PostController::getPostsAction() does not exist, or could not be auto-loaded in Sonata\NewsBundle\Controller\Api\PostController (which is being imported from "/www/config/routes/routes.yaml").").

I am targeting this branch, because is's a little fix.

## Changelog

```markdown
### Added
- Added conflict for unsupported `nelmio/api-doc-bundle` versions
```
