### PR TITLE
use Sonata\DatagridBundle\Pager\PageableInterface;

### DIFF
--- a/src/Model/CommentManagerInterface.php
+++ b/src/Model/CommentManagerInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle\Model;
 
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 
-interface CommentManagerInterface extends ManagerInterface, PageableManagerInterface
+interface CommentManagerInterface extends ManagerInterface, PageableInterface
 {
     /**
      * Update the number of comment for a comment.

--- a/src/Model/CommentManagerInterface.php
+++ b/src/Model/CommentManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Model;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\DatagridBundle\Pager\PageableInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface CommentManagerInterface extends ManagerInterface, PageableInterface
 {

--- a/src/Model/PostManagerInterface.php
+++ b/src/Model/PostManagerInterface.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle\Model;
 
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 
-interface PostManagerInterface extends ManagerInterface, PageableManagerInterface
+interface PostManagerInterface extends ManagerInterface, PageableInterface
 {
 }

--- a/src/Model/PostManagerInterface.php
+++ b/src/Model/PostManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Model;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\DatagridBundle\Pager\PageableInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface PostManagerInterface extends ManagerInterface, PageableInterface
 {

--- a/tests/Document/CommentManagerTest.php
+++ b/tests/Document/CommentManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\NewsBundle\Tests\Document;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\NewsBundle\Document\BaseComment;
 use Sonata\NewsBundle\Document\CommentManager;
 use Sonata\NewsBundle\Model\PostManagerInterface;
@@ -32,6 +32,6 @@ class CommentManagerTest extends TestCase
 
         $commentManager = new CommentManager(BaseComment::class, $registry, $postManager);
 
-        $this->assertInstanceOf(PageableManagerInterface::class, $commentManager);
+        $this->assertInstanceOf(PageableInterface::class, $commentManager);
     }
 }

--- a/tests/Document/PostManagerTest.php
+++ b/tests/Document/PostManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\NewsBundle\Tests\Document;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\NewsBundle\Document\BasePost;
 use Sonata\NewsBundle\Document\PostManager;
 
@@ -27,6 +27,6 @@ class PostManagerTest extends TestCase
 
         $postManager = new PostManager(BasePost::class, $registry);
 
-        $this->assertInstanceOf(PageableManagerInterface::class, $postManager);
+        $this->assertInstanceOf(PageableInterface::class, $postManager);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix deprecation
`The Sonata\Doctrine\Model\PageableManagerInterface class is deprecated since 1.3 in favor of Sonata\DatagridBundle\Pager\PageableInterface, and will be removed in 2.0.`


Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
use `Sonata\DatagridBundle\Pager\PageableInterface` instead of `Sonata\Doctrine\Model\PageableManagerInterface`;
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [X] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
