### PR TITLE
use Sonata\DatagridBundle\Pager\PageableInterface;

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sonata-project/admin-bundle": "^3.35",
         "sonata-project/classification-bundle": "^3.6",
         "sonata-project/core-bundle": "^3.13.7",
-        "sonata-project/datagrid-bundle": "^2.3",
+        "sonata-project/datagrid-bundle": "^2.4",
         "sonata-project/doctrine-extensions": "^1.1.3",
         "sonata-project/easy-extends-bundle": "^2.5",
         "sonata-project/formatter-bundle": "^3.4 || ^4.0",

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -384,7 +384,6 @@ class PostController
     /**
      * Filters criteria from $paramFetcher to be compatible with the Pager criteria.
      *
-     *
      * @return array The filtered criteria
      */
     protected function filterCriteria(ParamFetcherInterface $paramFetcher)

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -63,15 +63,11 @@ class SonataNewsExtension extends Extension
         }
 
         if (!isset($config['salt'])) {
-            throw new \InvalidArgumentException(
-                'The configuration node "salt" is not set for the SonataNewsBundle (sonata_news)'
-            );
+            throw new \InvalidArgumentException('The configuration node "salt" is not set for the SonataNewsBundle (sonata_news)');
         }
 
         if (!isset($config['comment'])) {
-            throw new \InvalidArgumentException(
-                'The configuration node "comment" is not set for the SonataNewsBundle (sonata_news)'
-            );
+            throw new \InvalidArgumentException('The configuration node "comment" is not set for the SonataNewsBundle (sonata_news)');
         }
 
         $container->getDefinition('sonata.news.hash.generator')

--- a/src/Model/CommentManagerInterface.php
+++ b/src/Model/CommentManagerInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle\Model;
 
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 
-interface CommentManagerInterface extends ManagerInterface, PageableManagerInterface
+interface CommentManagerInterface extends ManagerInterface, PageableInterface
 {
     /**
      * Update the number of comment for a comment.

--- a/src/Model/CommentManagerInterface.php
+++ b/src/Model/CommentManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Model;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\DatagridBundle\Pager\PageableInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface CommentManagerInterface extends ManagerInterface, PageableInterface
 {

--- a/src/Model/PostManagerInterface.php
+++ b/src/Model/PostManagerInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle\Model;
 
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 
-interface PostManagerInterface extends ManagerInterface, PageableManagerInterface
+interface PostManagerInterface extends ManagerInterface, PageableInterface
 {
     /**
      * @param string $permalink

--- a/src/Model/PostManagerInterface.php
+++ b/src/Model/PostManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Model;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\DatagridBundle\Pager\PageableInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 
 interface PostManagerInterface extends ManagerInterface, PageableInterface
 {

--- a/tests/Document/CommentManagerTest.php
+++ b/tests/Document/CommentManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\NewsBundle\Tests\Document;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\NewsBundle\Document\BaseComment;
 use Sonata\NewsBundle\Document\CommentManager;
 use Sonata\NewsBundle\Model\PostManagerInterface;
@@ -32,6 +32,6 @@ class CommentManagerTest extends TestCase
 
         $commentManager = new CommentManager(BaseComment::class, $registry, $postManager);
 
-        $this->assertInstanceOf(PageableManagerInterface::class, $commentManager);
+        $this->assertInstanceOf(PageableInterface::class, $commentManager);
     }
 }

--- a/tests/Document/PostManagerTest.php
+++ b/tests/Document/PostManagerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\NewsBundle\Tests\Document;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
-use Sonata\Doctrine\Model\PageableManagerInterface;
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\NewsBundle\Document\BasePost;
 use Sonata\NewsBundle\Document\PostManager;
 
@@ -27,6 +27,6 @@ class PostManagerTest extends TestCase
 
         $postManager = new PostManager(BasePost::class, $registry);
 
-        $this->assertInstanceOf(PageableManagerInterface::class, $postManager);
+        $this->assertInstanceOf(PageableInterface::class, $postManager);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix deprecation
`The Sonata\Doctrine\Model\PageableManagerInterface class is deprecated since 1.3 in favor of Sonata\DatagridBundle\Pager\PageableInterface, and will be removed in 2.0.`


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
use `Sonata\DatagridBundle\Pager\PageableInterface` instead of `Sonata\Doctrine\Model\PageableManagerInterface`;
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [X] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->