### PR TITLE
Remove tight coupling to user bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "sonata-project/formatter-bundle": "^3.4 || ^4.0",
         "sonata-project/intl-bundle": "^2.4",
         "sonata-project/media-bundle": "^3.10",
-        "sonata-project/user-bundle": "^3.6 || ^4.0",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
         "symfony/config": "^3.4 || ^4.2",
         "symfony/console": "^3.4 || ^4.2",

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -34,13 +34,11 @@ in ``bundles.php`` file of your project::
         Ivory\CKEditorBundle\IvoryCKEditorBundle::class => ['all' => true],
         Sonata\NewsBundle\SonataNewsBundle::class => ['all' => true],
         Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
-        Sonata\UserBundle\SonataUserBundle::class => ['all' => true],
         Sonata\MediaBundle\SonataMediaBundle::class => ['all' => true],
         Sonata\AdminBundle\SonataAdminBundle::class => ['all' => true],
         Sonata\IntlBundle\SonataIntlBundle::class => ['all' => true],
         Sonata\FormatterBundle\SonataFormatterBundle::class => ['all' => true],
         Sonata\ClassificationBundle\SonataClassificationBundle::class => ['all' => true],
-        FOS\UserBundle\FOSUserBundle::class => ['all' => true],
         Knp\Bundle\MarkdownBundle\KnpMarkdownBundle::class => ['all' => true],
         Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
         Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle::class => ['all' => true],
@@ -147,7 +145,6 @@ Generate the application bundles
 .. code-block:: bash
 
     bin/console sonata:easy-extends:generate SonataNewsBundle -d src
-    bin/console sonata:easy-extends:generate SonataUserBundle -d src
     bin/console sonata:easy-extends:generate SonataMediaBundle -d src
     bin/console sonata:easy-extends:generate SonataClassificationBundle -d src
 
@@ -161,7 +158,6 @@ Enable the application bundles
     return [
         // ...
         App\Application\Sonata\NewsBundle\ApplicationSonataNewsBundle::class => ['all' => true],
-        App\Application\Sonata\UserBundle\ApplicationSonataUserBundle::class => ['all' => true],
         App\Application\Sonata\MediaBundle\ApplicationSonataMediaBundle::class => ['all' => true],
         App\Application\Sonata\ClassificationBundle\ApplicationSonataClassificationBundle::class => ['all' => true],
     ];
@@ -188,8 +184,6 @@ Update Database Schema
 .. code-block:: bash
 
     bin/console doctrine:schema:update --force
-
-* Complete the FOS/UserBundle install and use the ``App\Application\Sonata\UserBundle\Entity\User`` as the user class
 
 Add SonataNewsBundle routes
 ---------------------------

--- a/src/Admin/PostAdmin.php
+++ b/src/Admin/PostAdmin.php
@@ -36,7 +36,9 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 class PostAdmin extends AbstractAdmin
 {
     /**
-     * @var UserManagerInterface
+     * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
+     *
+     * @var UserManagerInterface|null
      */
     protected $userManager;
 
@@ -51,7 +53,9 @@ class PostAdmin extends AbstractAdmin
     protected $permalinkGenerator;
 
     /**
-     * @param UserManagerInterface $userManager
+     * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
+     *
+     * @param UserManagerInterface|null $userManager
      */
     public function setUserManager($userManager)
     {

--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -15,11 +15,11 @@ namespace Sonata\NewsBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use FOS\UserBundle\Model\UserInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\Tag;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class Post implements PostInterface
 {

--- a/src/Model/PostInterface.php
+++ b/src/Model/PostInterface.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle\Model;
 
 use Doctrine\Common\Collections\Collection;
-use FOS\UserBundle\Model\UserInterface;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\ClassificationBundle\Model\TagInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 interface PostInterface
 {

--- a/src/Resources/config/doctrine_mongodb_admin.xml
+++ b/src/Resources/config/doctrine_mongodb_admin.xml
@@ -7,7 +7,7 @@
             <argument>%sonata.news.admin.post.entity%</argument>
             <argument>%sonata.news.admin.post.controller%</argument>
             <call method="setUserManager">
-                <argument type="service" id="fos_user.user_manager"/>
+                <argument type="service" id="fos_user.user_manager" on-invalid="null"/>
             </call>
             <call method="setPoolFormatter">
                 <argument type="service" id="sonata.formatter.pool"/>

--- a/src/Resources/config/doctrine_orm_admin.xml
+++ b/src/Resources/config/doctrine_orm_admin.xml
@@ -11,7 +11,7 @@
             <argument>%sonata.news.admin.post.entity%</argument>
             <argument>%sonata.news.admin.post.controller%</argument>
             <call method="setUserManager">
-                <argument type="service" id="fos_user.user_manager"/>
+                <argument type="service" id="fos_user.user_manager" on-invalid="null"/>
             </call>
             <call method="setPoolFormatter">
                 <argument type="service" id="sonata.formatter.pool"/>

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -21,7 +21,7 @@ use Sonata\MediaBundle\Model\Media;
 use Sonata\NewsBundle\DependencyInjection\SonataNewsExtension;
 use Sonata\NewsBundle\Model\Comment;
 use Sonata\NewsBundle\Model\Post;
-use Sonata\UserBundle\Model\User;
+use Sonata\NewsBundle\Tests\Fixtures\UserMock;
 
 class SonataNewsExtensionTest extends AbstractExtensionTestCase
 {
@@ -84,7 +84,7 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
                     'post' => Post::class,
                     'comment' => Comment::class,
                     'media' => Media::class,
-                    'user' => User::class,
+                    'user' => UserMock::class,
                 ],
             ];
     }

--- a/tests/Fixtures/UserMock.php
+++ b/tests/Fixtures/UserMock.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserMock implements UserInterface
+{
+    public function getRoles()
+    {
+    }
+
+    public function getPassword()
+    {
+    }
+
+    public function getSalt()
+    {
+    }
+
+    public function getUsername()
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

We don't need FOS or Sonata UserBundle, we can use the symfony UserInterface for everything.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed tight coupling to user bundle
- Removed `sonata-project/user-bundle` dependency

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
