### PR TITLE
Make admin bundle optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "sonata-project/admin-bundle": "^3.35",
         "sonata-project/classification-bundle": "^3.6",
         "sonata-project/core-bundle": "^3.13.7",
         "sonata-project/datagrid-bundle": "^2.3",
@@ -52,6 +51,7 @@
         "friendsofsymfony/rest-bundle": "<1.8 || >=3.0",
         "jms/serializer": "<0.13",
         "nelmio/api-doc-bundle": "<2.0 || >=3.0",
+        "sonata-project/admin-bundle": "<3.59",
         "sonata-project/block-bundle": "<3.18",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/notification-bundle": "<3.0 || >=4.0",
@@ -63,6 +63,7 @@
         "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "nelmio/api-doc-bundle": "^2.4",
+        "sonata-project/admin-bundle": "^3.59",
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/notification-bundle": "^3.3",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow using the bundle as a (frontend) bundle only.

There is already a check for a loaded AdminBundle, but the AdminBundle was required by composer.

https://github.com/sonata-project/SonataNewsBundle/blob/3.x/src/DependencyInjection/SonataNewsExtension.php#L61-L63


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataClassificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataClassificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Make admin bundle optional
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
