### PR TITLE
Fix clashing date filter call

### DIFF
--- a/src/Resources/views/Post/archive.rss.twig
+++ b/src/Resources/views/Post/archive.rss.twig
@@ -19,7 +19,7 @@
                   <title>{{ post.title }}</title>
                   <link>{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(post) }, true) }}</link>
                   <description><![CDATA[ {{ post.abstract }} ]]></description>
-                  <pubDate>{{ post.publicationDateStart | format_datetime('eee, MM LLL yyyy HH:mm:ss ZZZ', 'en')}}</pubDate>
+                  <pubDate>{{ post.publicationDateStart | date('Y-m-d\\TH:i:sP', 'UTC') }}</pubDate>
                   <guid>{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(post) }, true) }}</guid>
              </item>
         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There is a problem when calling `format_datetime` when you use SonataIntlBundle and TwigIntlBundle. Both bundles provide a `format_datetime` filter with a different signature.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix clashing `format_datetime` filter call
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
