### PR TITLE
Replace truncate filter with u filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "sonata-project/classification-bundle": "^3.6",
         "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-extensions": "^1.5.1",
@@ -45,7 +45,8 @@
         "symfony/routing": "^3.4 || ^4.2",
         "symfony/security-core": "^3.4 || ^4.2",
         "symfony/templating": "^3.4 || ^4.2",
-        "twig/twig": "^1.35 || ^2.4"
+        "twig/string-extra": "^3.0",
+        "twig/twig": "^2.12.1"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",
@@ -76,7 +77,8 @@
         "nelmio/api-doc-bundle": "If you want to use the API",
         "sonata-project/block-bundle": "For rendering block lists.",
         "sonata-project/doctrine-orm-admin-bundle": "^2.2",
-        "sonata-project/notification-bundle": "^2.2"
+        "sonata-project/notification-bundle": "^2.2",
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
     },
     "config": {
         "sort-packages": true

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -103,6 +104,7 @@ class SonataNewsExtension extends Extension
 
         $this->configureClass($config, $container);
         $this->configureAdmin($config, $container);
+        $this->configureStringExtension($container);
     }
 
     /**
@@ -260,5 +262,15 @@ class SonataNewsExtension extends Extension
                 ],
             'orphanRemoval' => false,
         ]);
+    }
+
+    private function configureStringExtension(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
+            $definition = new Definition(StringExtension::class);
+            $definition->addTag('twig.extension');
+
+            $container->setDefinition(StringExtension::class, $definition);
+        }
     }
 }

--- a/src/Resources/views/Admin/list_post_custom.html.twig
+++ b/src/Resources/views/Admin/list_post_custom.html.twig
@@ -38,7 +38,7 @@ file that was distributed with this source code.
         {% endif %}
         <br />
 
-        {{ object.abstract|truncate(150) }}
+        {{ object.abstract|u.truncate(150) }}
 
         <br />
         {% if object.collection %}

--- a/src/Resources/views/Block/recent_comments.html.twig
+++ b/src/Resources/views/Block/recent_comments.html.twig
@@ -48,13 +48,13 @@ file that was distributed with this source code.
                                 {% endif %}
                             </span>&nbsp;
 
-                            {{ comment.name }} - {{ comment.message|truncate(30) }}
+                            {{ comment.name }} - {{ comment.message|u.truncate(30) }}
                         </a>
                     {% else %}
                         <a class="list-group-item"
                            href="{{ url('sonata_news_view', { 'permalink': sonata_news_permalink(comment.post) }) }}"
                         >
-                            {{ comment.name }} - {{ comment.message|truncate(30) }}
+                            {{ comment.name }} - {{ comment.message|u.truncate(30) }}
                         </a>
                     {% endif %}
                 {% else %}

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -22,6 +22,7 @@ use Sonata\NewsBundle\DependencyInjection\SonataNewsExtension;
 use Sonata\NewsBundle\Model\Comment;
 use Sonata\NewsBundle\Model\Post;
 use Sonata\NewsBundle\Tests\Fixtures\UserMock;
+use Twig\Extra\String\StringExtension;
 
 class SonataNewsExtensionTest extends AbstractExtensionTestCase
 {
@@ -64,6 +65,13 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
         $this->assertCount(1, $postManyToManyAssociation, 'The post model should have 1 many to many association (tag)');
         $postOneToManyAssociation = $collector->getAssociations()[Post::class]['mapOneToMany'];
         $this->assertCount(1, $postOneToManyAssociation, 'The post model should have 1 one to many association (comment)');
+    }
+
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->load($this->getConfigurationWithTagWithCollection());
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getMinimalConfiguration(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This bundle was using `truncate` filter without explicitly require `twig/extensions`, with this PR it uses `u` filter.

I added `twig/extra-bundle` to autoload the Twig extension and a fallback in case Flex is not used.

Ref: sonata-project/SonataAdminBundle#6132


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `twig/string-extra` dependency.
### Changed
- Changed use of `truncate` filter with `u` filter.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
