### PR TITLE
Fix StringExtension registration

### DIFF
--- a/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+final class TwigStringExtensionCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
+            if (StringExtension::class === $container->getDefinition($id)->getClass()) {
+                return;
+            }
+        }
+
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $container->setDefinition(StringExtension::class, $definition);
+    }
+}

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Twig\Extra\String\StringExtension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -104,7 +103,6 @@ class SonataNewsExtension extends Extension
 
         $this->configureClass($config, $container);
         $this->configureAdmin($config, $container);
-        $this->configureStringExtension($container);
     }
 
     /**
@@ -262,15 +260,5 @@ class SonataNewsExtension extends Extension
                 ],
             'orphanRemoval' => false,
         ]);
-    }
-
-    private function configureStringExtension(ContainerBuilder $container): void
-    {
-        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
-            $definition = new Definition(StringExtension::class);
-            $definition->addTag('twig.extension');
-
-            $container->setDefinition(StringExtension::class, $definition);
-        }
     }
 }

--- a/src/SonataNewsBundle.php
+++ b/src/SonataNewsBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\NewsBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
+use Sonata\NewsBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,6 +22,8 @@ class SonataNewsBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+
         $this->registerFormMapping();
     }
 

--- a/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\NewsBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+class TwigStringExtensionCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
+    }
+
+    public function testLoadTwigStringExtensionWithExtraBundle(): void
+    {
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $this->container->setDefinition('twig.extension.string', $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('twig.extension.string', 'twig.extension');
+        $this->assertContainerBuilderNotHasService(StringExtension::class);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TwigEnvironmentPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/SonataNewsExtensionTest.php
+++ b/tests/DependencyInjection/SonataNewsExtensionTest.php
@@ -22,7 +22,6 @@ use Sonata\NewsBundle\DependencyInjection\SonataNewsExtension;
 use Sonata\NewsBundle\Model\Comment;
 use Sonata\NewsBundle\Model\Post;
 use Sonata\NewsBundle\Tests\Fixtures\UserMock;
-use Twig\Extra\String\StringExtension;
 
 class SonataNewsExtensionTest extends AbstractExtensionTestCase
 {
@@ -65,13 +64,6 @@ class SonataNewsExtensionTest extends AbstractExtensionTestCase
         $this->assertCount(1, $postManyToManyAssociation, 'The post model should have 1 many to many association (tag)');
         $postOneToManyAssociation = $collector->getAssociations()[Post::class]['mapOneToMany'];
         $this->assertCount(1, $postOneToManyAssociation, 'The post model should have 1 one to many association (comment)');
-    }
-
-    public function testLoadTwigStringExtension(): void
-    {
-        $this->load($this->getConfigurationWithTagWithCollection());
-
-        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getMinimalConfiguration(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR contains:
- move StringExtension registration to Compiler pass and check all `twig.extension` service to avoid duplication
- improve tests
- fix previus broken checking
```php
... !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) ...
// it is like this:   !is_a('Twig\Extra\String\StringExtension', StringExtension::class)) ...
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

PATCH for  non release #602.

