### PR TITLE
Fix TwigStringExtensionCompilerPass priority

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "sonata-project/intl-bundle": "^2.4",
         "sonata-project/media-bundle": "^3.20",
         "sonata-project/twig-extensions": "^0.1 || ^1.3",
-        "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
         "symfony/config": "^4.3",
         "symfony/console": "^4.3",
         "symfony/dependency-injection": "^4.3",
@@ -45,6 +44,7 @@
         "symfony/options-resolver": "^4.3",
         "symfony/routing": "^4.3",
         "symfony/security-core": "^4.3",
+        "symfony/swiftmailer-bundle": "^3.4",
         "symfony/templating": "^4.3",
         "twig/string-extra": "^3.0",
         "twig/twig": "^2.12.1"
@@ -72,6 +72,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.5",
         "sonata-project/notification-bundle": "^3.4",
         "sonata-project/seo-bundle": "^2.5",
+        "symfony/browser-kit": "^4.3",
         "symfony/phpunit-bridge": "^5.1"
     },
     "suggest": {

--- a/src/SonataNewsBundle.php
+++ b/src/SonataNewsBundle.php
@@ -15,6 +15,7 @@ namespace Sonata\NewsBundle;
 
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\NewsBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -22,7 +23,7 @@ class SonataNewsBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
 
         $this->registerFormMapping();
     }

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\App;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use JMS\SerializerBundle\JMSSerializerBundle;
+use Knp\Bundle\MenuBundle\KnpMenuBundle;
+use Sonata\BlockBundle\SonataBlockBundle;
+use Sonata\ClassificationBundle\SonataClassificationBundle;
+use Sonata\Doctrine\Bridge\Symfony\Bundle\SonataDoctrineBundle;
+use Sonata\Form\Bridge\Symfony\SonataFormBundle;
+use Sonata\IntlBundle\SonataIntlBundle;
+use Sonata\MediaBundle\SonataMediaBundle;
+use Sonata\NewsBundle\SonataNewsBundle;
+use Sonata\Twig\Bridge\Symfony\SonataTwigBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+final class AppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', false);
+    }
+
+    /**
+     * @return BundleInterface[]
+     */
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new SecurityBundle(),
+            new DoctrineBundle(),
+            new KnpMenuBundle(),
+            new SonataBlockBundle(),
+            new SonataDoctrineBundle(),
+            new SonataFormBundle(),
+            new SonataTwigBundle(),
+            new SonataClassificationBundle(),
+            new SonataIntlBundle(),
+            new SonataMediaBundle(),
+            new SonataNewsBundle(),
+            new JMSSerializerBundle(),
+            new SwiftmailerBundle(),
+        ];
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->getBaseDir().'cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->getBaseDir().'log';
+    }
+
+    public function getProjectDir()
+    {
+        return __DIR__;
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes->import($this->getProjectDir().'/config/routes.yaml');
+    }
+
+    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    {
+        $loader->load($this->getProjectDir().'/config/config.yaml');
+    }
+
+    private function getBaseDir(): string
+    {
+        return sys_get_temp_dir().'/sonata-news-bundle/var/';
+    }
+}

--- a/tests/App/Controller/TruncateController.php
+++ b/tests/App/Controller/TruncateController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TruncateController extends AbstractController
+{
+    public function test(): Response
+    {
+        return $this->render('truncate_test.html.twig');
+    }
+}

--- a/tests/App/Resources/views/truncate_test.html.twig
+++ b/tests/App/Resources/views/truncate_test.html.twig
@@ -1,0 +1,3 @@
+{% spaceless %}
+    {{ 'test for u.truncate'|u.truncate(4) }}
+{% endspaceless %}

--- a/tests/App/config/config.yaml
+++ b/tests/App/config/config.yaml
@@ -1,0 +1,37 @@
+imports:
+    - security.yaml
+    - sonata.yaml
+
+framework:
+    test: true
+    secret: secret
+    session:
+        handler_id: session.handler.native_file
+        storage_id: session.storage.mock_file
+        name: MOCKSESSID
+    translator:
+        enabled: true
+    form:
+        enabled: true
+    csrf_protection:
+        enabled: true
+    templating:
+        engines: [twig]
+
+twig:
+    form_themes:
+
+doctrine:
+    dbal:
+        url: 'sqlite:///%kernel.cache_dir%/data.db'
+    orm:
+        auto_generate_proxy_classes: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore
+        auto_mapping: true
+        mappings:
+            App:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/../../src/Entity'
+                prefix: 'App\Entity'
+                alias: App

--- a/tests/App/config/routes.yaml
+++ b/tests/App/config/routes.yaml
@@ -1,0 +1,3 @@
+test_page:
+    path: /u_truncate_test
+    controller: Sonata\NewsBundle\Tests\App\Controller\TruncateController:test

--- a/tests/App/config/security.yaml
+++ b/tests/App/config/security.yaml
@@ -1,0 +1,11 @@
+security:
+    providers:
+        users_in_memory: {memory: null}
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            anonymous: true
+            provider: users_in_memory
+    access_control:

--- a/tests/App/config/sonata.yaml
+++ b/tests/App/config/sonata.yaml
@@ -1,0 +1,34 @@
+sonata_news:
+    title: Sonata Project
+    link: https://sonata-project.org
+    description: Cool bundles on top of Symfony2
+    salt: 'secureToken'
+    permalink_generator: sonata.news.permalink.date
+    db_driver: 'no_driver'
+    comment:
+        notification:
+            emails: [email@example.org, email2@example.org]
+            from: no-reply@sonata-project.org
+            template: '@SonataNews/Mail/comment_notification.txt.twig'
+
+sonata_media:
+    db_driver: doctrine_orm
+    default_context: default
+    contexts:
+        default:
+            providers:
+                - sonata.media.provider.dailymotion
+                - sonata.media.provider.youtube
+                - sonata.media.provider.image
+                - sonata.media.provider.file
+                - sonata.media.provider.vimeo
+            formats:
+                small: {width: 100, quality: 70}
+                big: {width: 500, quality: 70}
+    cdn:
+        server:
+            path: /uploads/media
+    filesystem:
+        local:
+            directory: '%kernel.root_dir%/../public/uploads/media'
+            create: false

--- a/tests/Functional/Controller/TruncateControllerTest.php
+++ b/tests/Functional/Controller/TruncateControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\Functional\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\NewsBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TruncateControllerTest extends TestCase
+{
+    public function testTruncate(): void
+    {
+        $client = new Client(new AppKernel());
+        $client->request(Request::METHOD_GET, '/u_truncate_test');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertSame('test', $client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR fix case when `TwigStringExtensionCompilerPass` is build after `TwigEnvironmentPass` - then `u` filter is not registred.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix missing `u` filter when `SonataNewsBundle` is register after `TwigBundle`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
