### PR TITLE
Update Swagger definition in order to be compatible with string ident…

### DIFF
--- a/src/Controller/Api/CommentController.php
+++ b/src/Controller/Api/CommentController.php
@@ -44,7 +44,7 @@ class CommentController
      * @ApiDoc(
      *  resource=true,
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Comment identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Comment identifier"}
      *  },
      *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -55,7 +55,7 @@ class CommentController
      *
      * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int $id Comment identifier
+     * @param string $id Comment identifier
      *
      * @throws NotFoundHttpException
      *
@@ -71,7 +71,7 @@ class CommentController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Comment identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Comment identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when comment is successfully deleted",
@@ -80,7 +80,7 @@ class CommentController
      *  }
      * )
      *
-     * @param int $id Comment identifier
+     * @param string $id Comment identifier
      *
      * @throws NotFoundHttpException
      *
@@ -102,7 +102,7 @@ class CommentController
     /**
      * Returns a comment entity instance.
      *
-     * @param int $id Comment identifier
+     * @param string $id Comment identifier
      *
      * @throws NotFoundHttpException
      *

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -106,7 +106,7 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Post identifier"}
      *  },
      *  output={"class"="sonata_news_api_form_post", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -117,7 +117,7 @@ class PostController
      *
      * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int $id A post identifier
+     * @param string $id Post identifier
      *
      * @return Post
      */
@@ -154,7 +154,7 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Post identifier"}
      *  },
      *  input={"class"="sonata_news_api_form_post", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_news_api_form_post", "groups"={"sonata_api_read"}},
@@ -165,7 +165,7 @@ class PostController
      *  }
      * )
      *
-     * @param int     $id      Post identifier
+     * @param string  $id      Post identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -182,7 +182,7 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Post identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when post is successfully deleted",
@@ -191,7 +191,7 @@ class PostController
      *  }
      * )
      *
-     * @param int $id Post identifier
+     * @param string $id Post identifier
      *
      * @throws NotFoundHttpException
      *
@@ -215,7 +215,7 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Post identifier"}
      *  },
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -229,7 +229,7 @@ class PostController
      *
      * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int $id Post identifier
+     * @param string $id Post identifier
      *
      * @return PagerInterface
      */
@@ -254,7 +254,7 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Post identifier"}
      *  },
      *  input={"class"="sonata_news_api_form_comment", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"={"sonata_api_read"}},
@@ -268,7 +268,7 @@ class PostController
      *
      * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int $id Post identifier
+     * @param string $id Post identifier
      *
      * @throws HttpException
      *
@@ -310,8 +310,8 @@ class PostController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="postId", "dataType"="integer", "requirement"="\d+", "description"="Post identifier"},
-     *      {"name"="commentId", "dataType"="integer", "requirement"="\d+", "description"="Comment identifier"}
+     *      {"name"="postId", "dataType"="string", "description"="Post identifier"},
+     *      {"name"="commentId", "dataType"="string", "description"="Comment identifier"}
      *  },
      *  input={"class"="sonata_news_api_form_comment", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\NewsBundle\Model\Comment", "groups"={"sonata_api_read"}},
@@ -324,8 +324,8 @@ class PostController
      *
      * @REST\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int     $postId    Post identifier
-     * @param int     $commentId Comment identifier
+     * @param string  $postId    Post identifier
+     * @param string  $commentId Comment identifier
      * @param Request $request   Symfony request
      *
      * @throws NotFoundHttpException
@@ -399,7 +399,7 @@ class PostController
     /**
      * Retrieves post with id $id or throws an exception if it doesn't exist.
      *
-     * @param int $id Post identifier
+     * @param string $id Post identifier
      *
      * @throws NotFoundHttpException
      *
@@ -419,8 +419,8 @@ class PostController
     /**
      * Write a post, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Post identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Post identifier
      *
      * @return View|FormInterface
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Update OpenAPI (Swagger) definition in order to be compatible with string identifiers (like UUIDs).

These changes are consistent with the API narrowing made at sonata-project/admin-bundle (see AdminInterface::id()).

I am targeting this branch, because these changes respect BC.

Part of https://github.com/sonata-project/dev-kit/issues/778

Based on: https://github.com/sonata-project/SonataUserBundle/pull/1198

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed requirements that were only allowing integers for model identifiers at Open API definitions.
### Fixed
- Fixed support for string model identifiers at Open API definitions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
