### PR TITLE
♻️  Remove some deprecations

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -9,6 +9,11 @@ Please read [3.x](https://github.com/sonata-project/SonataNewsBundle/tree/3.x) u
 
 See also the [diff code](https://github.com/sonata-project/SonataNewsBundle/compare/3.x...4.0.0).
 
+## CommentManager/PostManager (document and entity)
+
+If you have implemented a custom manager, you must adapt the signature of `getPager` method to return
+a `PagerInterface`
+
 ## PostManager
 
 If you have implemented a custom post manager, you must adapt the signature of the following new methods to match the one in `PostManagerInterface` again:
@@ -17,3 +22,8 @@ If you have implemented a custom post manager, you must adapt the signature of t
  * `getPublicationDateQueryParts`
 
 If you are using mongodb, you have to use `PostManager::findOneBySlug` instead of `PostManager::findOneByPermalink`.
+
+## Controllers
+
+If you have extended a controller, they are now extending `Symfony\Bundle\FrameworkBundle\Controller\AbstractController` instead of deprecated
+`Symfony\Bundle\FrameworkBundle\Controller\Controller`

--- a/src/Action/AbstractPostArchiveAction.php
+++ b/src/Action/AbstractPostArchiveAction.php
@@ -16,12 +16,12 @@ namespace Sonata\NewsBundle\Action;
 use Sonata\NewsBundle\Model\BlogInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Translation\TranslatorInterface;
 
-abstract class AbstractPostArchiveAction extends Controller
+abstract class AbstractPostArchiveAction extends AbstractController
 {
     /**
      * @var BlogInterface

--- a/src/Action/CommentListAction.php
+++ b/src/Action/CommentListAction.php
@@ -15,10 +15,10 @@ namespace Sonata\NewsBundle\Action;
 
 use Sonata\NewsBundle\Model\CommentInterface;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
-final class CommentListAction extends Controller
+final class CommentListAction extends AbstractController
 {
     /**
      * @var CommentManagerInterface

--- a/src/Action/CreateCommentAction.php
+++ b/src/Action/CreateCommentAction.php
@@ -24,7 +24,7 @@ use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Sonata\NewsBundle\SonataNewsEvents;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -34,7 +34,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-final class CreateCommentAction extends Controller
+final class CreateCommentAction extends AbstractController
 {
     /**
      * @var RouterInterface

--- a/src/Action/CreateCommentFormAction.php
+++ b/src/Action/CreateCommentFormAction.php
@@ -17,13 +17,13 @@ use Sonata\NewsBundle\Form\Type\CommentType;
 use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
-final class CreateCommentFormAction extends Controller
+final class CreateCommentFormAction extends AbstractController
 {
     /**
      * @var RouterInterface

--- a/src/Action/ViewPostAction.php
+++ b/src/Action/ViewPostAction.php
@@ -17,13 +17,13 @@ use Sonata\NewsBundle\Model\BlogInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
-final class ViewPostAction extends Controller
+final class ViewPostAction extends AbstractController
 {
     /**
      * @var BlogInterface

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -37,7 +37,7 @@ use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Sonata\NewsBundle\Model\PostInterface;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,7 +45,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class PostController extends Controller
+class PostController extends AbstractController
 {
     /**
      * @return RedirectResponse

--- a/src/Document/CommentManager.php
+++ b/src/Document/CommentManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Document;
 
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Document\BaseDocumentManager;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
@@ -25,10 +26,8 @@ class CommentManager extends BaseDocumentManager implements CommentManagerInterf
     /**
      * @param int $page
      * @param int $limit
-     *
-     * @return Pager
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): PagerInterface
     {
         $qb = $this->getDocumentManager()->getRepository($this->class)
             ->createQueryBuilder()

--- a/src/Document/PostManager.php
+++ b/src/Document/PostManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\NewsBundle\Document;
 
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Document\BaseDocumentManager;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
@@ -82,7 +83,7 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
      *    collections - CollectionInterface
      *    mode - string public|admin.
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): PagerInterface
     {
         if (!isset($criteria['mode'])) {
             $criteria['mode'] = 'public';

--- a/src/Entity/CommentManager.php
+++ b/src/Entity/CommentManager.php
@@ -15,6 +15,7 @@ namespace Sonata\NewsBundle\Entity;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\Doctrine\Model\ManagerInterface;
@@ -71,7 +72,7 @@ class CommentManager extends BaseEntityManager implements CommentManagerInterfac
         $this->updateCommentsCount($post);
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): PagerInterface
     {
         if (!isset($criteria['mode'])) {
             $criteria['mode'] = 'public';

--- a/src/Entity/PostManager.php
+++ b/src/Entity/PostManager.php
@@ -16,6 +16,7 @@ namespace Sonata\NewsBundle\Entity;
 use Doctrine\ORM\Query\Expr\Join;
 use Sonata\ClassificationBundle\Model\CollectionInterface;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\NewsBundle\Model\BlogInterface;
@@ -84,7 +85,7 @@ class PostManager extends BaseEntityManager implements PostManagerInterface
      *    collections - CollectionInterface
      *    mode - string public|admin.
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): PagerInterface
     {
         if (!isset($criteria['mode'])) {
             $criteria['mode'] = 'public';

--- a/tests/Controller/Api/PostControllerTest.php
+++ b/tests/Controller/Api/PostControllerTest.php
@@ -27,13 +27,26 @@ class PostControllerTest extends TestCase
 {
     public function testGetPostsAction(): void
     {
+        $parameters = [
+            'page' => 2,
+            'count' => 5,
+        ];
+
         $paramFetcher = $this->createMock('FOS\RestBundle\Request\ParamFetcherInterface');
         $paramFetcher->expects($this->once())->method('all')->willReturn([]);
+        $paramFetcher->expects($this->exactly(2))->method('get')
+            ->with($this->logicalOr($this->equalTo('page'), $this->equalTo('count')))
+            ->willReturnCallback(static function ($parameter) use ($parameters) {
+                return $parameters[$parameter];
+            });
 
         $pager = $this->createMock('Sonata\DatagridBundle\Pager\PagerInterface');
 
         $postManager = $this->createMock('Sonata\NewsBundle\Model\PostManagerInterface');
-        $postManager->expects($this->once())->method('getPager')->willReturn($pager);
+        $postManager->expects($this->once())
+            ->method('getPager')
+            ->with($this->anything(), $this->equalTo($parameters['page']), $this->equalTo($parameters['count']))
+            ->willReturn($pager);
 
         $this->assertSame($pager, $this->createPostController($postManager)->getPostsAction($paramFetcher));
     }

--- a/tests/Functional/Controller/TruncateControllerTest.php
+++ b/tests/Functional/Controller/TruncateControllerTest.php
@@ -15,7 +15,7 @@ namespace Sonata\NewsBundle\Tests\Functional\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\NewsBundle\Tests\App\AppKernel;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,7 +23,7 @@ final class TruncateControllerTest extends TestCase
 {
     public function testTruncate(): void
     {
-        $client = new Client(new AppKernel());
+        $client = new KernelBrowser(new AppKernel());
         $client->request(Request::METHOD_GET, '/u_truncate_test');
 
         $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Unfortunately it's easier to open a new PR than rebasing the #646 branch, then this is the follow up.

Remove some deprecations:
- using SF4.2 `AbstractController`
- using SF4.3 `HttpKernelBrowser`
- using `Sonata\DatagridBundle\Pager\PageableInterface`

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting master, because for the many BC break (#646 )

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecated usage of `Symfony\Component\HttpKernel\Client`
- Deprecated usage of `Symfony\Bundle\FrameworkBundle\Controller\Controller`
- Deprecated usage of `Sonata\Doctrine\Model\PageableManagerInterface`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
