### PR TITLE
Allow to use "symfony/mailer" within `Mailer`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\NewsBundle\Mailer\Mailer
+
+Passing an instance of `\Swift_Mailer` as argument 1  for `Sonata\NewsBundle\Mailer\Mailer::__construct()`
+is deprecated. Pass an instance of `Symfony\Component\Mailer\MailerInterface` instead.
+
 UPGRADE FROM 3.13 to 3.14
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,11 @@
         "symfony/framework-bundle": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
+        "symfony/mailer": "^4.4 || ^5.1",
+        "symfony/mime": "^4.4.10 || ^5.1",
         "symfony/options-resolver": "^4.4",
         "symfony/routing": "^4.4",
         "symfony/security-core": "^4.4",
-        "symfony/swiftmailer-bundle": "^3.4",
         "symfony/templating": "^4.4 || ^5.1",
         "symfony/translation-contracts": "^1.1 || ^2.0",
         "twig/string-extra": "^3.0",
@@ -74,7 +75,8 @@
         "sonata-project/notification-bundle": "^3.4",
         "sonata-project/seo-bundle": "^2.5",
         "symfony/browser-kit": "^4.3",
-        "symfony/phpunit-bridge": "^5.1.8"
+        "symfony/phpunit-bridge": "^5.1.8",
+        "symfony/swiftmailer-bundle": "^3.4"
     },
     "suggest": {
         "nelmio/api-doc-bundle": "If you want to use the API.",

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -124,12 +124,15 @@ class Mailer implements MailerInterface
             return;
         }
 
-        $this->mailer->send(
-            (new Email())
+        $email = (new Email())
                 ->from($fromEmail)
-                ->to($toEmail)
                 ->subject($subject)
-                ->html($body)
-        );
+                ->html($body);
+
+        foreach ($this->emails['notification']['emails'] as $address) {
+            $email->addTo($address);
+        }
+
+        $this->mailer->send($email);
     }
 }

--- a/tests/Mailer/MailerTest.php
+++ b/tests/Mailer/MailerTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 
-class MailerTest extends TestCase
+final class MailerTest extends TestCase
 {
     /**
      * @var RouterInterface|MockObject
@@ -48,7 +48,9 @@ class MailerTest extends TestCase
     private $templating;
 
     /**
-     * @var Mailer
+     * NEXT_MAJOR: Remove the support for `\Swift_Mailer` in this property.
+     *
+     * @var SymfonyMailerInterface|\Swift_Mailer
      */
     private $mailer;
 
@@ -60,9 +62,9 @@ class MailerTest extends TestCase
     protected function setUp(): void
     {
         $this->mailer = $this->createMock(SymfonyMailerInterface::class);
-        $this->blog = $this->createMock(BlogInterface::class);
+        $this->blog = $this->createStub(BlogInterface::class);
         $this->generator = $this->createMock(HashGeneratorInterface::class);
-        $this->router = $this->createMock(RouterInterface::class);
+        $this->router = $this->createStub(RouterInterface::class);
         $this->templating = $this->createMock(EngineInterface::class);
         $this->emails = [
             'notification' => [
@@ -182,14 +184,11 @@ class MailerTest extends TestCase
         $mailer->sendCommentNotification($comment);
     }
 
-    public function emailTemplateData(): array
+    public function emailTemplateData(): iterable
     {
         return [
-            //'CR' => ["Subject\rFirst line\rSecond line", 'Subject', "First line\rSecond line"],
             'LF' => ["Subject\nFirst line\nSecond line", 'Subject', "First line\nSecond line"],
-            //'CRLF' => ["Subject\r\nFirst line\r\nSecond line", 'Subject', "First line\r\nSecond line"],
             'LFLF' => ["Subject\n\nFirst line\n\nSecond line", 'Subject', "\nFirst line\n\nSecond line"],
-            //'CRCR' => ["Subject\r\rFirst line\r\rSecond line", 'Subject', "\rFirst line\r\rSecond line"],
         ];
     }
 

--- a/tests/Mailer/MailerTest.php
+++ b/tests/Mailer/MailerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\NewsBundle\Tests\Mailer;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\NewsBundle\Mailer\Mailer;
+use Sonata\NewsBundle\Model\BlogInterface;
+use Sonata\NewsBundle\Model\CommentInterface;
+use Sonata\NewsBundle\Model\PostInterface;
+use Sonata\NewsBundle\Util\HashGeneratorInterface;
+use Symfony\Component\Mailer\MailerInterface as SymfonyMailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class MailerTest extends TestCase
+{
+    /**
+     * @var RouterInterface|MockObject
+     */
+    private $router;
+
+    /**
+     * @var BlogInterface|MockObject
+     */
+    private $blog;
+
+    /**
+     * @var HashGeneratorInterface|MockObject
+     */
+    private $generator;
+
+    /**
+     * @var EngineInterface|MockObject
+     */
+    private $templating;
+
+    /**
+     * @var Mailer
+     */
+    private $mailer;
+
+    /**
+     * @var array
+     */
+    private $emails;
+
+    protected function setUp(): void
+    {
+        $this->mailer = $this->createMock(SymfonyMailerInterface::class);
+        $this->blog = $this->createMock(BlogInterface::class);
+        $this->generator = $this->createMock(HashGeneratorInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+        $this->emails = [
+            'notification' => [
+                'template' => 'email_test.html.twig',
+                'from' => 'news-bundle@sonata-project.org',
+                'emails' => ['news-bundle@sonata-project.org', 'news-bundle-anoher@sonata-project.org'],
+            ],
+        ];
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     *
+     * @dataProvider emailTemplateData
+     */
+    public function testSendCommentNotificationWithSwiftMailer(string $template, string $subject, string $body): void
+    {
+        $post = $this->createMock(PostInterface::class);
+
+        $comment = $this->createStub(CommentInterface::class);
+        $comment
+            ->expects($this->once())
+            ->method('getPost')
+            ->willReturn($post);
+
+        $this->generator
+            //->expects($this->once())
+            ->method('generate')
+            ->with($comment)
+            ->willReturn('some_result');
+
+        $this->emails['notification']['template'] = $template;
+
+        $this->templating
+            ->expects($this->once())
+            ->method('render')
+            ->with($this->emails['notification']['template'], [
+                'comment' => $comment,
+                'post' => $post,
+                'hash' => 'some_result',
+                'blog' => $this->blog,
+            ])
+            ->willReturn($template);
+
+        $message = (new \Swift_Message())
+            ->setSubject($subject)
+            ->setFrom($this->emails['notification']['from'])
+            ->setTo($this->emails['notification']['emails'])
+            ->setBody($body);
+
+        $this->mailer = $this->createStub(\Swift_Mailer::class);
+        $this->mailer
+            ->expects($this->once())
+            ->method('createMessage')
+            ->willReturn($message);
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($message);
+
+        $mailer = $this->getMailer();
+
+        $mailer->sendCommentNotification($comment);
+    }
+
+    /**
+     * @dataProvider emailTemplateData
+     */
+    public function testSendCommentNotification(string $template, string $subject, string $body): void
+    {
+        $post = $this->createMock(PostInterface::class);
+
+        $comment = $this->createStub(CommentInterface::class);
+        $comment
+            ->expects($this->once())
+            ->method('getPost')
+            ->willReturn($post);
+
+        $this->generator
+            //->expects($this->once())
+            ->method('generate')
+            ->with($comment)
+            ->willReturn('some_result');
+
+        $this->emails['notification']['template'] = $template;
+
+        $this->templating
+            ->expects($this->once())
+            ->method('render')
+            ->with($this->emails['notification']['template'], [
+                'comment' => $comment,
+                'post' => $post,
+                'hash' => 'some_result',
+                'blog' => $this->blog,
+            ])
+            ->willReturn($template);
+
+        $email = (new Email())
+            ->from($this->emails['notification']['from'])
+            ->subject($subject)
+            ->html($body);
+
+        foreach ($this->emails['notification']['emails'] as $address) {
+            $email->addTo($address);
+        }
+
+        $this->mailer
+            ->expects($this->once())
+            ->method('send')
+            ->with($email);
+
+        $mailer = $this->getMailer();
+
+        $mailer->sendCommentNotification($comment);
+    }
+
+    public function emailTemplateData(): array
+    {
+        return [
+            //'CR' => ["Subject\rFirst line\rSecond line", 'Subject', "First line\rSecond line"],
+            'LF' => ["Subject\nFirst line\nSecond line", 'Subject', "First line\nSecond line"],
+            //'CRLF' => ["Subject\r\nFirst line\r\nSecond line", 'Subject', "First line\r\nSecond line"],
+            'LFLF' => ["Subject\n\nFirst line\n\nSecond line", 'Subject', "\nFirst line\n\nSecond line"],
+            //'CRCR' => ["Subject\r\rFirst line\r\rSecond line", 'Subject', "\rFirst line\r\rSecond line"],
+        ];
+    }
+
+    private function getMailer(): Mailer
+    {
+        return new Mailer($this->mailer, $this->blog, $this->generator, $this->router, $this->templating, $this->emails);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Allow to use "symfony/mailer" within Mailer.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNewsBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for "symfony/mailer" in `Sonata\NewsBundle\Mailer\Mailer`.
### Deprecated
- Support for "swiftmailer/swiftmailer" in `Sonata\NewsBundle\Mailer\Mailer`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
