### PR TITLE
Deprecate ReST API

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Deprecate API
+
+Integration with FOSRest, JMS Serializer and Nelmio Api Docs is deprecated, the ReST API provided with this bundle will be removed on 4.0.
+
+If you are relying on this, consider moving to other solution like [API Platform](https://api-platform.com/) instead.
+
 UPGRADE FROM 3.16 to 3.17
 =========================
 

--- a/src/Controller/Api/CommentController.php
+++ b/src/Controller/Api/CommentController.php
@@ -21,7 +21,11 @@ use Sonata\NewsBundle\Model\CommentManagerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
  */
 class CommentController
 {

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -32,7 +32,11 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
  */
 class PostController
 {

--- a/src/DependencyInjection/SonataNewsExtension.php
+++ b/src/DependencyInjection/SonataNewsExtension.php
@@ -44,6 +44,7 @@ class SonataNewsExtension extends Extension
         $loader->load('twig.xml');
         $loader->load('form.xml');
         $loader->load('core.xml');
+        // NEXT_MAJOR: Remove next line and the file.
         $loader->load('serializer.xml');
         $loader->load('command.xml');
 
@@ -51,6 +52,7 @@ class SonataNewsExtension extends Extension
             $loader->load('block.xml');
         }
 
+        // NEXT_MAJOR: Remove this condition and remove all configuration files related to this.
         if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
             $loader->load(sprintf('api_form_%s.xml', $config['db_driver']));
             if ('doctrine_orm' === $config['db_driver']) {

--- a/src/Document/CommentManager.php
+++ b/src/Document/CommentManager.php
@@ -23,6 +23,10 @@ use Sonata\NewsBundle\Model\PostInterface;
 class CommentManager extends BaseDocumentManager implements CommentManagerInterface
 {
     /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
+     *
      * @param int $page
      * @param int $limit
      *

--- a/src/Document/PostManager.php
+++ b/src/Document/PostManager.php
@@ -103,6 +103,10 @@ class PostManager extends BaseDocumentManager implements PostManagerInterface
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
+     *
      * Valid criteria are:
      *    enabled - boolean
      *    date - query

--- a/src/Form/Type/ApiCommentType.php
+++ b/src/Form/Type/ApiCommentType.php
@@ -16,7 +16,11 @@ namespace Sonata\NewsBundle\Form\Type;
 use Sonata\Form\Type\BaseDoctrineORMSerializationType;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
+ *
+ * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
  */
 class ApiCommentType extends BaseDoctrineORMSerializationType
 {

--- a/src/Form/Type/ApiPostType.php
+++ b/src/Form/Type/ApiPostType.php
@@ -16,7 +16,11 @@ namespace Sonata\NewsBundle\Form\Type;
 use Sonata\Form\Type\BaseDoctrineORMSerializationType;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
+ *
+ * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
  */
 class ApiPostType extends BaseDoctrineORMSerializationType
 {

--- a/src/Model/CommentManagerInterface.php
+++ b/src/Model/CommentManagerInterface.php
@@ -16,6 +16,9 @@ namespace Sonata\NewsBundle\Model;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
+/**
+ * NEXT_MAJOR: Remove PageableManagerInterface extension.
+ */
 interface CommentManagerInterface extends ManagerInterface, PageableManagerInterface
 {
     /**

--- a/src/Model/PostManagerInterface.php
+++ b/src/Model/PostManagerInterface.php
@@ -16,6 +16,9 @@ namespace Sonata\NewsBundle\Model;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
+/**
+ * NEXT_MAJOR: Remove PageableManagerInterface extension.
+ */
 interface PostManagerInterface extends ManagerInterface, PageableManagerInterface
 {
 }

--- a/src/Serializer/PostSerializerHandler.php
+++ b/src/Serializer/PostSerializerHandler.php
@@ -16,7 +16,11 @@ namespace Sonata\NewsBundle\Serializer;
 use Sonata\Form\Serializer\BaseSerializerHandler;
 
 /**
+ * NEXT_MAJOR: Remove this file and the serializer configuration for Gallery.
+ *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/news-bundle 3.x, to be removed in 4.0.
  */
 class PostSerializerHandler extends BaseSerializerHandler
 {

--- a/tests/Controller/Api/CommentControllerTest.php
+++ b/tests/Controller/Api/CommentControllerTest.php
@@ -17,7 +17,11 @@ use PHPUnit\Framework\TestCase;
 use Sonata\NewsBundle\Controller\Api\CommentController;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @group legacy
  */
 class CommentControllerTest extends TestCase
 {

--- a/tests/Controller/Api/PostControllerTest.php
+++ b/tests/Controller/Api/PostControllerTest.php
@@ -21,7 +21,11 @@ use Sonata\NewsBundle\Model\CommentInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @group legacy
  */
 class PostControllerTest extends TestCase
 {

--- a/tests/Document/CommentManagerTest.php
+++ b/tests/Document/CommentManagerTest.php
@@ -21,7 +21,11 @@ use Sonata\NewsBundle\Document\CommentManager;
 use Sonata\NewsBundle\Model\PostManagerInterface;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * Tests the comment manager document.
+ *
+ * @group legacy
  */
 class CommentManagerTest extends TestCase
 {

--- a/tests/Document/PostManagerTest.php
+++ b/tests/Document/PostManagerTest.php
@@ -19,6 +19,11 @@ use Sonata\Doctrine\Model\PageableManagerInterface;
 use Sonata\NewsBundle\Document\BasePost;
 use Sonata\NewsBundle\Document\PostManager;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
+ */
 class PostManagerTest extends TestCase
 {
     public function testImplements()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated ReST API with FOSRest, Nelmio Api Docs and JMS Serializer.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
